### PR TITLE
response: add a module for basic parsing of XML requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ codecov = { repository = "3scale-rs/threescalers" }
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["http-types"]
+default = ["http-types", "xml-response"]
 
 # Add in conversions for http's crate types
 http-types = []
@@ -34,6 +34,8 @@ reqwest-sync = ["reqwest-types"]
 reqwest-all = ["reqwest-async", "reqwest-sync"]
 # Include all supported clients types
 all-types = ["http-types", "reqwest-all"]
+# Response parsing
+xml-response = ["serde-xml-rs", "serde"]
 # Internal feature, auto-enabled via build.rs when using nightly
 nightly = []
 
@@ -42,6 +44,8 @@ error-chain = "^0.12"
 percent-encoding = "^1"
 http_types = { version = "^0.1", package = "http" }
 reqwest = { version = "^0.9", optional = true }
+serde = { version = "*", optional = true, features = ["derive"] }
+serde-xml-rs = { version = "*", optional = true }
 
 [build-dependencies]
 rustc_version = "^0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ reqwest-all = ["reqwest-async", "reqwest-sync"]
 # Include all supported clients types
 all-types = ["http-types", "reqwest-all"]
 # Response parsing
-xml-response = ["serde-xml-rs", "serde"]
+xml-response = ["serde-xml-rs", "serde", "chrono"]
 # Internal feature, auto-enabled via build.rs when using nightly
 nightly = []
 
@@ -46,6 +46,7 @@ http_types = { version = "^0.1", package = "http" }
 reqwest = { version = "^0.9", optional = true }
 serde = { version = "*", optional = true, features = ["derive"] }
 serde-xml-rs = { version = "*", optional = true }
+chrono = { version = "^0.4", optional = true }
 
 [build-dependencies]
 rustc_version = "^0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,9 @@ pub mod user;
 pub mod version;
 
 pub mod timestamp;
+#[cfg(feature = "xml-response")]
+pub mod response;
+
 
 use std::borrow::Cow;
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -8,6 +8,18 @@ use std::time::SystemTime;
 #[derive(Debug, PartialEq)]
 pub struct PeriodTime(SystemTime);
 
+impl From<SystemTime> for PeriodTime {
+    fn from(st: SystemTime) -> Self {
+        PeriodTime(st)
+    }
+}
+
+impl From<PeriodTime> for SystemTime {
+    fn from(pt: PeriodTime) -> Self {
+        pt.0
+    }
+}
+
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename = "usage_report")]
 pub struct UsageReport {

--- a/src/response.rs
+++ b/src/response.rs
@@ -24,7 +24,7 @@ enum URWrapper {
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename = "status")]
 pub struct Authorization {
-    authorized: String,
+    authorized: bool,
     plan: String,
     usage_reports: Vec<URWrapper>,
 }
@@ -87,6 +87,19 @@ mod tests {
 
         let parsed_auth = Authorization::from_str(s).unwrap();
 
-        println!("Parsed: {:#?}", parsed_auth);
+        let expected_auth = Authorization {
+            authorized: true,
+            plan: String::from("App Plan"),
+            usage_reports: vec![URWrapper::UsageReport(UsageReport {
+                metric: String::from("products"),
+                period: String::from("minute"),
+                period_start: String::from("2019-06-05 16:24:00 +0000"),
+                period_end: String::from("2019-06-05 16:25:00 +0000"),
+                max_value: 5,
+                current_value: 0,
+            })],
+        };
+
+        assert_eq!(parsed_auth, expected_auth);
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -16,9 +16,9 @@ pub struct UsageReport {
 // Unfortunately the XML output from Apisonator includes a rather useless "usage_reports" tag that
 // is then followed by a "usage_report" tag in each UsageReport, so we need to wrap that up.
 #[derive(Debug, Deserialize, PartialEq)]
-enum URWrapper {
+pub enum UsageReports {
     #[serde(rename = "usage_report")]
-    UsageReport(UsageReport),
+    UsageReports(Vec<UsageReport>),
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -26,7 +26,7 @@ enum URWrapper {
 pub struct Authorization {
     authorized: bool,
     plan: String,
-    usage_reports: Vec<URWrapper>,
+    usage_reports: UsageReports,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -81,6 +81,12 @@ mod tests {
                     <max_value>5</max_value>
                     <current_value>0</current_value>
                 </usage_report>
+                <usage_report metric="products" period="month">
+                    <period_start>2019-06-01 00:00:00 +0000</period_start>
+                    <period_end>2019-07-01 00:00:00 +0000</period_end>
+                    <max_value>50</max_value>
+                    <current_value>0</current_value>
+                </usage_report>
             </usage_reports>
         </status>
         "##;
@@ -90,14 +96,24 @@ mod tests {
         let expected_auth = Authorization {
             authorized: true,
             plan: String::from("App Plan"),
-            usage_reports: vec![URWrapper::UsageReport(UsageReport {
-                metric: String::from("products"),
-                period: String::from("minute"),
-                period_start: String::from("2019-06-05 16:24:00 +0000"),
-                period_end: String::from("2019-06-05 16:25:00 +0000"),
-                max_value: 5,
-                current_value: 0,
-            })],
+            usage_reports: UsageReports::UsageReports(vec![
+                UsageReport {
+                    metric: String::from("products"),
+                    period: String::from("minute"),
+                    period_start: String::from("2019-06-05 16:24:00 +0000"),
+                    period_end: String::from("2019-06-05 16:25:00 +0000"),
+                    max_value: 5,
+                    current_value: 0,
+                },
+                UsageReport {
+                    metric: String::from("products"),
+                    period: String::from("month"),
+                    period_start: String::from("2019-06-01 00:00:00 +0000"),
+                    period_end: String::from("2019-07-01 00:00:00 +0000"),
+                    max_value: 50,
+                    current_value: 0,
+                },
+            ]),
         };
 
         assert_eq!(parsed_auth, expected_auth);

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,0 +1,92 @@
+use serde::Deserialize;
+use std::str::FromStr;
+use std::time::SystemTime;
+
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename = "usage_report")]
+pub struct UsageReport {
+    pub metric: String,
+    pub period: String,
+    pub period_start: String,
+    pub period_end: String,
+    pub max_value: u64,
+    pub current_value: u64,
+}
+
+// Unfortunately the XML output from Apisonator includes a rather useless "usage_reports" tag that
+// is then followed by a "usage_report" tag in each UsageReport, so we need to wrap that up.
+#[derive(Debug, Deserialize, PartialEq)]
+enum URWrapper {
+    #[serde(rename = "usage_report")]
+    UsageReport(UsageReport),
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename = "status")]
+pub struct Authorization {
+    authorized: String,
+    plan: String,
+    usage_reports: Vec<URWrapper>,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct PeriodInstance {
+    start: SystemTime,
+    end: SystemTime,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub enum Period {
+    Minute(PeriodInstance),
+    Hour(PeriodInstance),
+    Day(PeriodInstance),
+    Week(PeriodInstance),
+    Month(PeriodInstance),
+    Year(PeriodInstance),
+    Eternity,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct UsageData {
+    max_value: u64,
+    current_value: u64,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Metric(pub String);
+
+impl FromStr for Authorization {
+    type Err = serde_xml_rs::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_xml_rs::from_str(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse() {
+        let s = r##"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <status>
+            <authorized>true</authorized>
+            <plan>App Plan</plan>
+            <usage_reports>
+                <usage_report metric="products" period="minute">
+                    <period_start>2019-06-05 16:24:00 +0000</period_start>
+                    <period_end>2019-06-05 16:25:00 +0000</period_end>
+                    <max_value>5</max_value>
+                    <current_value>0</current_value>
+                </usage_report>
+            </usage_reports>
+        </status>
+        "##;
+
+        let parsed_auth = Authorization::from_str(s).unwrap();
+
+        println!("Parsed: {:#?}", parsed_auth);
+    }
+}


### PR DESCRIPTION
This is a draft so far, just to test the deserialization of XML bodies. The fields are currently declared as `String`s but period data should be deserialized into proper timestamps. Other things like headers would be supported via `Response` objects from similar libraries as those supported by `Request`s.