### PR TITLE
Migrate to 3scale-rs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -195,6 +195,10 @@ before_cache:
 
 branches:
   only:
+    # This is where pull requests from "bors r+" are built.
+    - staging
+    # This is where pull requests from "bors try" are built.
+    - trying
     # release tags
     - /^v\d+\.\d+\.\d+.*$/
     - master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,12 @@ repository = "https://github.com/3scale-rs/threescalers"
 readme = "README.md"
 keywords = ["3scale", "api-management", "api", "apisonator"]
 categories = ["api-bindings"]
+exclude = [
+    "bors.toml",
+    ".appveyor.yml",
+    ".travis.yml",
+    "ci",
+]
 
 [badges]
 appveyor = { repository = "3scale-rs/threescalers" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,15 +5,15 @@ description = "3scale API client library for Rust"
 version = "0.1.0"
 authors = ["Alejandro Martinez Ruiz <alex@flawedcode.org>", "David Ortiz Lopez <z.david.ortiz@gmail.com>"]
 license = "Apache-2.0"
-repository = "https://github.com/unleashed/threescalers"
+repository = "https://github.com/3scale-rs/threescalers"
 readme = "README.md"
 keywords = ["3scale", "api-management", "api", "apisonator"]
 categories = ["api-bindings"]
 
 [badges]
-appveyor = { repository = "unleashed/threescalers" }
-travis-ci = { repository = "unleashed/threescalers" }
-codecov = { repository = "unleashed/threescalers" }
+appveyor = { repository = "3scale-rs/threescalers" }
+travis-ci = { repository = "3scale-rs/threescalers" }
+codecov = { repository = "3scale-rs/threescalers" }
 maintenance = { status = "actively-developed" }
 
 [features]

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## Rust library crate for the 3scale Service Management API
 
-[![Build Status](https://travis-ci.org/unleashed/threescalers.svg?branch=master)](https://travis-ci.org/unleashed/threescalers)
-[![Build status](https://ci.appveyor.com/api/projects/status/gt8jxqp9n21f3qhe/branch/master?svg=true)](https://ci.appveyor.com/project/unleashed/threescalers/branch/master)
-[![codecov.io](https://codecov.io/gh/unleashed/threescalers/coverage.svg?branch=master)](https://codecov.io/gh/unleashed/threescalers/branch/master)
+[![Build Status](https://travis-ci.org/3scale-rs/threescalers.svg?branch=master)](https://travis-ci.org/3scale-rs/threescalers)
+[![Build status](https://ci.appveyor.com/api/projects/status/gf7okt6bbiqf2l1d/branch/master?svg=true)](https://ci.appveyor.com/project/3scale-rs/threescalers/branch/master)
+[![codecov.io](https://codecov.io/gh/3scale-rs/threescalers/coverage.svg?branch=master)](https://codecov.io/gh/3scale-rs/threescalers/branch/master)
 
-[Documentation](https://unleashed.github.io/threescalers/)
+[Documentation](https://3scale-rs.github.io/threescalers/)

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,4 @@
+status = ["continuous-integration/travis-ci/push"]
+pr_status = ["continuous-integration/travis-ci/pr"]
+block_labels = ["wip"]
+delete_merged_branches = true


### PR DESCRIPTION
This changes repo slugs, configures bors and excludes CI infrastructure from the crate package.