### PR TITLE
Cargo.toml: remove cargo build warnings due to new matching of excludes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "bors.toml",
     ".appveyor.yml",
     ".travis.yml",
-    "ci",
+    "/ci/**",
 ]
 
 [badges]


### PR DESCRIPTION
Currently cargo will warn about some files being excluded (and we want them excluded!). Silence that warning by using the recommended pattern.