### PR TITLE
Explain call to next_key() even when the key is not needed

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -112,7 +112,10 @@ impl<'de> Visitor<'de> for TimestampVisitor {
     where
         V: MapAccess<'de>,
     {
-        // We know there's only one key with one value - Note: probably safe to skip
+        // We know there's only one key with one value.
+        // The key is not used, but we need to call "next_key()". From the
+        // docs: "Calling `next_value` before `next_key` is incorrect and is
+        // allowed to panic or return bogus results.".
         let _key: Option<String> = map.next_key()?;
         let timestamp: String = map.next_value()?;
 


### PR DESCRIPTION
Ref: https://github.com/3scale-rs/threescalers/pull/27#discussion_r300827579