### PR TITLE
cargo: config for an alias for the reqwest example

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,4 @@
+[alias]
+# run examples in cargo by prefixing the example name with "ex-":
+# cargo ex-reqwest-report
+ex-reqwest-report = "run --example reqwest-report --features reqwest-sync"


### PR DESCRIPTION
This will allow users to quickly run specific examples without
having to look up which specific flags to use.