### PR TITLE
libcurl support

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -2,3 +2,4 @@
 # run examples in cargo by prefixing the example name with "ex-":
 # cargo ex-reqwest-report
 ex-reqwest-report = "run --example reqwest-report --features reqwest-sync"
+ex-curl-report = "run --example curl-report --features curl-easy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,12 @@ reqwest-types = ["reqwest"]
 reqwest-async = ["reqwest-types"]
 reqwest-sync = ["reqwest-types"]
 reqwest-all = ["reqwest-async", "reqwest-sync"]
+# Add in conversions for curl's crate types
+curl-types = ["curl"]
+curl-easy = ["curl-types"]
+curl-all = ["curl-easy"]
 # Include all supported clients types
-all-types = ["http-types", "reqwest-all"]
+all-types = ["http-types", "reqwest-all", "curl-all"]
 # Response parsing
 xml-response = ["serde-xml-rs", "serde", "chrono"]
 # Internal feature, auto-enabled via build.rs when using nightly
@@ -44,6 +48,7 @@ error-chain = "^0.12"
 percent-encoding = "^1"
 http_types = { version = "^0.1", package = "http" }
 reqwest = { version = "^0.9", optional = true }
+curl = { version = "^0.4", optional = true }
 serde = { version = "^1", optional = true, features = ["derive"] }
 serde-xml-rs = { version = "^0.3", optional = true }
 chrono = { version = "^0.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,5 +60,9 @@ rustc_version = "^0.2"
 name = "reqwest-report"
 required-features = ["reqwest-sync"]
 
+[[example]]
+name = "curl-report"
+required-features = ["curl-easy"]
+
 [dev-dependencies]
 serde_json = "^1.0"

--- a/examples/curl-report.rs
+++ b/examples/curl-report.rs
@@ -1,0 +1,103 @@
+use threescalers::api_call::*;
+use threescalers::application::*;
+use threescalers::credentials::*;
+use threescalers::extensions::Extensions;
+use threescalers::http::request::FromRequest;
+use threescalers::http::Request;
+use threescalers::service::*;
+use threescalers::transaction::Transaction;
+use threescalers::usage::Usage;
+
+use threescalers::http::request::curl::CurlEasyClient;
+
+use curl::easy::Easy;
+
+fn main() -> Result<(), threescalers::errors::Error> {
+    let creds = Credentials::ServiceToken(ServiceToken::from("12[3]token"));
+    let svc = Service::new("svc123", creds);
+    let uks = [
+        "userkey_1",
+        "userkey_2",
+        "userkey_3",
+        "userkey 4",
+        "userkey 5",
+    ];
+    let apps = uks
+        .into_iter()
+        .map(|uk| Application::from(UserKey::from(*uk)))
+        .collect::<Vec<_>>();
+
+    println!("Apps: {:#?}", apps);
+
+    let usages = [
+        ("metric11", 11),
+        ("metric12", 12),
+        ("metric21", 21),
+        ("metric22", 22),
+        ("metric31", 31),
+        ("metric32", 32),
+        ("metric41", 41),
+        ("metric42", 42),
+        ("metric51", 51),
+        ("metric52", 52),
+    ]
+    .chunks(2)
+    .map(|metrics_and_values| Usage::new(metrics_and_values))
+    .collect::<Vec<_>>();
+
+    println!("Usages: {:#?}", usages);
+
+    let ts = Default::default();
+
+    let txns = apps
+        .iter()
+        .zip(&usages)
+        .map(|(a, u)| Transaction::new(a, None, Some(u), Some(&ts)))
+        .collect::<Vec<_>>();
+
+    let mut extensions = Extensions::new();
+    extensions.insert("no_body", "1");
+    extensions.insert("testing[=]", "0[=:=]0");
+    let mut apicall = ApiCall::builder(&svc);
+    let apicall = apicall
+        .transactions(&txns)
+        .extensions(&extensions)
+        .kind(Kind::Report)
+        .build()?;
+    let request = Request::from(&apicall);
+
+    println!("apicall: {:#?}", apicall);
+    println!("request: {:#?}", request);
+
+    let _ = run_request(request);
+
+    Ok(())
+}
+
+fn run_request(request: Request) -> Result<(), curl::Error> {
+    let mut client = Easy::new();
+    let _ = client.verbose(true).unwrap();
+    let curlclient =
+        CurlEasyClient::from_request(request, (&mut client, "https://echo-api.3scale.net"));
+    let result = exec_request(&curlclient);
+    show_response(curlclient, result)
+}
+
+fn exec_request(curlc: &CurlEasyClient) -> Result<(), curl::Error> {
+    println!("CurlClient: {:#?}", curlc);
+    curlc.perform()
+}
+
+// Not looking directly at the response but using the verbose mode.
+fn show_response(curlc: CurlEasyClient, res: Result<(), curl::Error>) -> Result<(), curl::Error> {
+    match res {
+        Ok(_) => {
+            println!("*** SUCCESS ***\n{:#?}", curlc);
+            Ok(())
+        }
+        Err(e) => {
+            println!("*** ERROR ***\n{:#?}", e);
+            Err(e)
+        }
+    }
+}

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -6,6 +6,8 @@ use crate::ToParams;
 
 use super::Parameters;
 
+#[cfg(feature = "curl-types")]
+pub mod curl;
 #[cfg(feature = "http-types")]
 mod http;
 #[cfg(feature = "reqwest-types")]

--- a/src/http/request/curl.rs
+++ b/src/http/request/curl.rs
@@ -1,0 +1,133 @@
+#[cfg(feature = "curl-easy")]
+pub use easy::CurlEasyClient;
+
+#[cfg(feature = "curl-easy")]
+mod easy {
+    use super::super::{FromRequest, Request};
+    use curl::easy::{Easy, List, Transfer};
+    use http_types::header::HeaderValue;
+    use http_types::Method;
+
+    fn headermap_to_curl_list(headermap: &http_types::HeaderMap<HeaderValue>) -> List {
+        let mut list = List::new();
+        headermap.iter().for_each(|(k, v)| {
+            // this will scan for printable US-ASCII only bytes
+            let header = v
+                .to_str()
+                .map(|hval| [k.as_str(), ": ", hval].concat())
+                .expect("found header value without a displayable US-ASCII string");
+            list.append(header.as_str())
+                .expect("failed to allocate node for curl list of headers");
+        });
+        list
+    }
+
+    #[derive(Debug)]
+    pub enum CurlEasyClient<'easy, 'data> {
+        Easy(&'easy Easy),
+        Transfer(Transfer<'easy, 'data>),
+    }
+
+    impl<'easy, 'data> From<Transfer<'easy, 'data>> for CurlEasyClient<'easy, 'data> {
+        fn from(t: Transfer<'easy, 'data>) -> Self {
+            Self::Transfer(t)
+        }
+    }
+
+    impl<'easy> From<&'easy Easy> for CurlEasyClient<'easy, '_> {
+        fn from(e: &'easy Easy) -> Self {
+            Self::Easy(e)
+        }
+    }
+
+    impl<'easy, 'data> CurlEasyClient<'easy, 'data> {
+        pub fn new(easy: &'easy Easy) -> Self {
+            Self::Easy(easy)
+        }
+
+        pub fn perform(&self) -> Result<(), curl::Error> {
+            match self {
+                Self::Easy(e) => e.perform(),
+                Self::Transfer(t) => t.perform(),
+            }
+        }
+
+        pub fn into_transfer(self) -> Option<Transfer<'easy, 'data>> {
+            match self {
+                Self::Transfer(t) => Some(t),
+                Self::Easy(_) => None,
+            }
+        }
+
+        pub fn easy(&self) -> Option<&'easy Easy> {
+            if let Self::Easy(e) = self {
+                Some(e)
+            } else {
+                None
+            }
+        }
+    }
+
+    impl<'easy, 'data, URI: ToString> FromRequest<(&'easy mut Easy, URI)>
+        for CurlEasyClient<'easy, 'data>
+    {
+        fn from_request(r: Request, params: (&'easy mut Easy, URI)) -> Self {
+            let (uri, body) = r.parameters.uri_and_body(r.path);
+            let (client, uri_base) = params;
+            let uri = uri_base.to_string() + uri.as_ref();
+
+            match r.method {
+                Method::GET => client.get(true),
+                Method::POST => client.post(true),
+                Method::PUT => client.put(true),
+                // any other verb needs to use custom_request()
+                m => client.custom_request(m.as_str()),
+            }
+            .expect("failed to set up the request's method");
+
+            client
+                .url(uri.as_str())
+                .expect("error setting up url for curl");
+            let mut headerlist = headermap_to_curl_list(&r.headers);
+            // libcurl by default adds "Expect: 100-continue" to send bodies, which would break us
+            headerlist
+                .append("Expect:")
+                .expect("failed to allocate node for curl list of headers");
+            // don't specify Content-Type for this request (similar to other clients)
+            headerlist
+                .append("Content-Type:")
+                .expect("failed to allocate node for curl list of headers");
+            client
+                .http_headers(headerlist)
+                .expect("error setting up headers for curl");
+
+            match body {
+                Some(_) => {
+                    use std::io::Read;
+
+                    let body = r.parameters.into_inner();
+                    // this sets the Content-Length - some servers will misbehave without this
+                    client
+                        .post_field_size(body.len() as u64)
+                        .expect("failed to set post size");
+                    let mut transfer = client.transfer();
+
+                    let mut count = 0usize;
+                    transfer
+                        .read_function(move |buf| {
+                            let mut bytes = &body.as_bytes()[count..];
+                            let newcount = bytes
+                                .read(buf)
+                                .expect("error while copying body data to buffer");
+                            count += newcount;
+                            Ok(newcount)
+                        })
+                        .expect("failed to set up read function for curl");
+
+                    transfer.into()
+                }
+                None => (client as &Easy).into(),
+            }
+        }
+    }
+}


### PR DESCRIPTION
This introduces libcurl support with the `curl::Easy` client. We'll probably also provide support for the `Easy2` client too in the future at least.

Note that the fact we create our own type is needed to enable usage of the `transfer()` method in the client when posting data. Depending on how usage progresses we might need further changes.

We also add an example which currently mostly copies the Reqwest one.