### PR TITLE
Refactor FromRequest to make it more ergonomic and convey actual meaning

### DIFF
--- a/examples/curl-report.rs
+++ b/examples/curl-report.rs
@@ -4,15 +4,16 @@ use threescalers::{
     credentials::*,
     extensions::Extensions,
     http::{
-        request::FromRequest,
+        request::{
+            curl::CurlEasyClient,
+            SetupRequest,
+        },
         Request,
     },
     service::*,
     transaction::Transaction,
     usage::Usage,
 };
-
-use threescalers::http::request::curl::CurlEasyClient;
 
 use curl::easy::Easy;
 
@@ -69,7 +70,7 @@ fn main() -> Result<(), threescalers::errors::Error> {
 fn run_request(request: Request) -> Result<(), curl::Error> {
     let mut client = Easy::new();
     let _ = client.verbose(true).unwrap();
-    let curlclient = CurlEasyClient::from_request(request, (&mut client, "https://echo-api.3scale.net"));
+    let curlclient = client.setup_request(request, "https://echo-api.3scale.net");
     let result = exec_request(&curlclient);
     show_response(curlclient, result)
 }

--- a/examples/reqwest-report.rs
+++ b/examples/reqwest-report.rs
@@ -4,7 +4,7 @@ use threescalers::{
     credentials::*,
     extensions::Extensions,
     http::{
-        request::FromRequest,
+        request::SetupRequest,
         Request,
     },
     service::*,
@@ -69,8 +69,8 @@ fn main() -> Result<(), threescalers::errors::Error> {
 }
 
 fn run_request(request: Request) -> Result<Response, reqwest::Error> {
-    let client = Client::new();
-    let reqbuilder = RequestBuilder::from_request(request, (&client, "https://echo-api.3scale.net"));
+    let mut client = Client::new();
+    let reqbuilder = client.setup_request(request, "https://echo-api.3scale.net");
     let result = exec_request(reqbuilder);
     show_response(result)
 }

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -52,8 +52,13 @@ impl Request {
     }
 }
 
-pub trait FromRequest<P> {
-    fn from_request(r: Request, params: P) -> Self;
+/// This trait needs to be implemented by each client to set up a specific request.
+///
+/// The 'client lifetime will be useful if your Output return value needs to get hold of it. Such
+/// is the case of curl's Easy client when sending POST requests via their Transfer<'client, 'data>
+/// type, but for other clients which don't need to wrap the original client it's simply elided.
+pub trait SetupRequest<'client, P, Output> {
+    fn setup_request(&'client mut self, r: Request, params: P) -> Output;
 }
 
 impl From<&ApiCall<'_, '_, '_, '_, '_, '_>> for Request {

--- a/src/http/request/http.rs
+++ b/src/http/request/http.rs
@@ -3,7 +3,10 @@ use crate::{
     api_call::ApiCall,
     version::*,
 };
-use http_types::Request as HTTPRequest;
+use http_types::{
+    request::Builder,
+    Request as HTTPRequest,
+};
 
 impl From<Request> for HTTPRequest<String> {
     fn from(r: Request) -> Self {
@@ -25,11 +28,11 @@ impl From<&ApiCall<'_, '_, '_, '_, '_, '_>> for HTTPRequest<String> {
     }
 }
 
-use super::FromRequest;
+use super::SetupRequest;
 use crate::Never;
 
-impl FromRequest<Never> for HTTPRequest<String> {
-    fn from_request(r: Request, _params: Never) -> Self {
-        Self::from(r)
+impl SetupRequest<'_, Never, HTTPRequest<String>> for Builder {
+    fn setup_request(&mut self, r: Request, _params: Never) -> HTTPRequest<String> {
+        HTTPRequest::from(r)
     }
 }

--- a/src/http/request/reqwest.rs
+++ b/src/http/request/reqwest.rs
@@ -1,6 +1,6 @@
 use super::{
-    FromRequest,
     Request,
+    SetupRequest,
 };
 
 macro_rules! reqwest_impl {
@@ -9,13 +9,13 @@ macro_rules! reqwest_impl {
         //
         // https://a_host
         //
-        impl<URI: ToString> FromRequest<(&$C, URI)> for $B {
-            fn from_request(r: Request, params: (&$C, URI)) -> Self {
+        impl<URI: ToString> SetupRequest<'_, URI, $B> for $C {
+            fn setup_request(&mut self, r: Request, params: URI) -> $B {
                 let (uri, body) = r.parameters.uri_and_body(r.path);
-                let (client, uri_base) = params;
+                let uri_base = params;
                 let uri = uri_base.to_string() + uri.as_ref();
 
-                let rb = client.request(r.method, uri.as_str()).headers(r.headers);
+                let rb = self.request(r.method, uri.as_str()).headers(r.headers);
 
                 match body {
                     // when there is a body just consume it from the request's

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 #[cfg(all(test, feature = "nightly"))]
 extern crate test;
 
-// Define a never type useful for some traits (ie. FromRequest)
+// Define a never type useful for some traits (ie. SetupRequest)
 #[cfg(feature = "nightly")]
 pub type Never = !;
 #[cfg(not(feature = "nightly"))]


### PR DESCRIPTION
The previous trait, while working, had some ergonomic issues. For
example, it did require in some cases for the implementation to
create the client, and in others it required a mutable reference or
a move in the generic parameters.
    
It also used a free-standing function to do this, and in some cases
it required non-obvious types to call it on.
    
The new trait feels more natural while maintaining the flexibility,
in which we now require a client to exist before configuring our
request to be sent off. This change should convey that impls will no
longer create the clients, but just set them up with whatever is
required to perform a call.