### PR TITLE
Add minimal behaviour to MetricsHierarchy

### DIFF
--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -10,7 +10,7 @@ use std::{
     iter::FromIterator,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Extensions(HashMap<String, String>);
 
 impl Extensions {
@@ -22,8 +22,8 @@ impl Extensions {
         self.0.insert(param.into(), value.into())
     }
 
-    pub fn remove<R: AsRef<String>, S: Into<R>>(&mut self, param: S) -> Option<String> {
-        self.0.remove(param.into().as_ref())
+    pub fn remove<S: AsRef<str>>(&mut self, param: S) -> Option<String> {
+        self.0.remove(param.as_ref())
     }
 
     pub fn iter(&self) -> Iter<String, String> {

--- a/src/response.rs
+++ b/src/response.rs
@@ -30,7 +30,7 @@ impl From<PeriodTime> for SystemTime {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Default)]
 pub struct MetricsHierarchy(HashMap<String, Vec<String>>);
 
 impl MetricsHierarchy {


### PR DESCRIPTION
This adds some useful methods to `MetricsHierarchy` to allow doing useful work with it.

(while at it we also fix a couple of clippy suggestions, including one about `Extensions` which is essentially the same type as `MetricsHierarchy`)