### PR TITLE
Convert some comments to docs

### DIFF
--- a/src/http/request/curl/easy2.rs
+++ b/src/http/request/curl/easy2.rs
@@ -9,25 +9,25 @@ use curl::easy::{
 };
 use http_types::Method;
 
-// This trait has to be implemented by the Easy2<H>'s H generic type, as well as curl's Handler.
-// This is because the body of POST requests needs to be pushed from the storage associated to
-// that type, so this trait provides a method to store the body String and a method to copy data
-// by providing just an offset as multiple calls to push the data happen.
+/// This trait has to be implemented by the Easy2<H>'s H generic type, as well as curl's Handler.
+/// This is because the body of POST requests needs to be pushed from the storage associated to
+/// that type, so this trait provides a method to store the body String and a method to copy data
+/// by providing just an offset as multiple calls to push the data happen.
 pub trait SetBody: Handler {
-    // Static method to copy data over starting from an offset, return the number of bytes that
-    // were copied and updating the offset.
+    /// Static method to copy data over starting from an offset, return the number of bytes that
+    /// were copied and updating the offset.
     #[inline]
     fn copy_data(offset: &mut usize, source: &[u8], dest: &mut [u8]) -> usize {
         super::copy_data(offset, source, dest)
     }
 
-    // This method should store the body data to be pushed by this request.
+    /// This method should store the body data to be pushed by this request.
     fn set_body(&mut self, body: String);
 }
 
-// A default type that works with the requirements of conversion between a Request and a set up
-// Easy2 client by implementing the SetBody trait.
-#[derive(Debug)]
+/// A default type that works with the requirements of conversion between a Request and a set up
+/// Easy2 client by implementing the SetBody trait.
+#[derive(Debug, Clone)]
 pub struct BodyHandle {
     count: usize,
     body:  Option<String>,
@@ -39,6 +39,7 @@ impl BodyHandle {
                body:  None, }
     }
 
+    /// A method to set/unset the body. To be used from a SetBody trait impl.
     pub fn with_body(&mut self, body: Option<String>) {
         self.body = body;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,13 +29,13 @@ pub mod timestamp;
 
 use std::borrow::Cow;
 
-// This is the trait to be implemented by structures that can set parameters to API calls.
-//
-// Note that the 'this lifetime requires a lifetime long enough to keep keys and values.
-// The keys can potentially be modified to adapt them to the specific call circumstances,
-// so in order to take advantage of single allocations when modifications are not needed,
-// a copy-on-write type is used. Values are always kept as is, so just references are ok.
-pub trait ToParams<'k, 'v, 'this, E>
+/// This is the trait to be implemented by structures that can set parameters to API calls.
+///
+/// Note that the 'this lifetime requires a lifetime long enough to keep keys and values.
+/// The keys can potentially be modified to adapt them to the specific call circumstances,
+/// so in order to take advantage of single allocations when modifications are not needed,
+/// a copy-on-write type is used. Values are always kept as is, so just references are ok.
+pub(crate) trait ToParams<'k, 'v, 'this, E>
     where 'this: 'k + 'v,
           E: Extend<(Cow<'k, str>, &'v str)>
 {


### PR DESCRIPTION
The only other relevant changes are:

- Adding a missing `Clone` trait.
- Stop making `ToParams` public (only crate-public).

This is a draft PR because these docs would benefit from a bit more work on them (ie. specifying structs as [`TheStruct`] and similar, and maybe some extra docs for the 0.2 release.

Edit: just going to leave it as is to have the 0.2 release done.