### PR TITLE
Snafu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ xml-response = ["serde-xml-rs", "serde", "chrono"]
 nightly = []
 
 [dependencies]
-error-chain = "^0.12"
+snafu = "^0.4"
 percent-encoding = "^1"
 http_types = { version = "^0.1", package = "http" }
 reqwest = { version = "^0.9", optional = true }

--- a/src/application.rs
+++ b/src/application.rs
@@ -14,6 +14,30 @@ pub struct UserKey(String);
 #[derive(Debug, Clone, PartialEq)]
 pub struct OAuthToken(String);
 
+impl AppId {
+    fn new(s: &str) -> AppId {
+        AppId(String::from(s))
+    }
+}
+
+impl AppKey {
+    fn new(s: &str) -> AppKey {
+        AppKey(String::from(s))
+    }
+}
+
+impl UserKey {
+    fn new(s: &str) -> UserKey {
+        UserKey(String::from(s))
+    }
+}
+
+impl OAuthToken {
+    fn new(s: &str) -> OAuthToken {
+        OAuthToken(String::from(s))
+    }
+}
+
 // These trait impls provide a way to reference our types as &str
 impl AsRef<str> for AppId {
     fn as_ref(&self) -> &str {
@@ -76,28 +100,28 @@ impl FromStr for OAuthToken {
 impl<'a> From<&'a str> for AppId where Self: FromStr
 {
     fn from(s: &'a str) -> AppId {
-        s.parse().unwrap()
+        AppId::new(s)
     }
 }
 
 impl<'a> From<&'a str> for AppKey where Self: FromStr
 {
     fn from(s: &'a str) -> AppKey {
-        s.parse().unwrap()
+        AppKey::new(s)
     }
 }
 
 impl<'a> From<&'a str> for UserKey where Self: FromStr
 {
     fn from(s: &'a str) -> UserKey {
-        s.parse().unwrap()
+        UserKey::new(s)
     }
 }
 
 impl<'a> From<&'a str> for OAuthToken where Self: FromStr
 {
     fn from(s: &'a str) -> OAuthToken {
-        s.parse().unwrap()
+        OAuthToken::new(s)
     }
 }
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -41,7 +41,7 @@ impl AsRef<str> for OAuthToken {
 
 // These trait impls provide a way to &str#parse() our Application type
 impl FromStr for AppId {
-    type Err = Error;
+    type Err = ThreescalersError;
 
     fn from_str(s: &str) -> Result<AppId> {
         Ok(AppId(s.into()))
@@ -49,7 +49,7 @@ impl FromStr for AppId {
 }
 
 impl FromStr for AppKey {
-    type Err = Error;
+    type Err = ThreescalersError;
 
     fn from_str(s: &str) -> Result<AppKey> {
         Ok(AppKey(s.into()))
@@ -57,7 +57,7 @@ impl FromStr for AppKey {
 }
 
 impl FromStr for UserKey {
-    type Err = Error;
+    type Err = ThreescalersError;
 
     fn from_str(s: &str) -> Result<UserKey> {
         Ok(UserKey(s.into()))
@@ -65,7 +65,7 @@ impl FromStr for UserKey {
 }
 
 impl FromStr for OAuthToken {
-    type Err = Error;
+    type Err = ThreescalersError;
 
     fn from_str(s: &str) -> Result<OAuthToken> {
         Ok(OAuthToken(s.into()))

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -31,7 +31,7 @@ impl AsRef<str> for ServiceToken {
 
 // These trait impls provide a way to &str#parse()
 impl FromStr for ProviderKey {
-    type Err = Error;
+    type Err = ThreescalersError;
 
     fn from_str(s: &str) -> Result<ProviderKey> {
         Ok(ProviderKey(s.into()))
@@ -39,7 +39,7 @@ impl FromStr for ProviderKey {
 }
 
 impl FromStr for ServiceToken {
-    type Err = Error;
+    type Err = ThreescalersError;
 
     fn from_str(s: &str) -> Result<ServiceToken> {
         Ok(ServiceToken(s.into()))
@@ -144,7 +144,7 @@ impl AsRef<str> for ServiceId {
 }
 
 impl FromStr for ServiceId {
-    type Err = Error;
+    type Err = ThreescalersError;
 
     fn from_str(s: &str) -> Result<ServiceId> {
         Ok(ServiceId(s.into()))

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,59 @@
-use error_chain::error_chain;
+// make the err_val macro available to the crate
+#![macro_use]
 
-error_chain! {
-    errors {
-        // TODO: fill with our own stuff
-    }
+// re-publishing here for ease of use of modules using this
+#[allow(unused_imports)]
+pub(crate) use snafu::{
+    ensure,
+    Backtrace,
+    OptionExt,
+    ResultExt,
+    Snafu,
+};
+
+// This macro is meant to generate the Error value of a snafu error for usage in
+// contexts where the actual snafu error variant value is needed, such as in
+// Option#ok_or_else()?. You just pass in the snafu struct representing the error
+// variant and get back the enum type with a value matching that error variant.
+//
+// Note that the snafu's fail() fn receives a type parameter for the Result type
+// it must generate, but since it will always be an error and we just unwrap it
+// right away, we should not need to concern ourselves with it and can tell the
+// compiler that a Result with the Ok variant will never happen.
+macro_rules! err_val {
+    ($e:expr) => {
+        $e.fail::<crate::Never>().unwrap_err()
+    };
 }
+
+// A general API error type.
+//
+// The snafu crate mostly prods you to add local error types in modules, which is
+// a good design strategy. However, some of those might end up eventually translated
+// into a more general error, and this would be it. The decision on doing that has
+// not yet been taken, so we might end up declaring several local error types as part
+// of the public API contract. Currently this serves as a fallback for those places
+// where we don't yet have a local error type defined.
+//
+// Note: the non-exhaustiveness is meant for public API enums to force users to
+// be forward-compatible when we add extra errors to these enums. Stable rust does
+// not currently provide a proper way to do this, so a __Nonexhaustive variant is
+// maintained at the end of this enum. Nightly already has a proper way to handle
+// this via a feature flag.
+//
+// Note: before we commit to an error API, we should look into making this an opaque
+// type. The snafu crate has some documentation around this we can use to consider how
+// to best make this a part of the API.
+#[derive(Debug, Snafu)]
+#[cfg_attr(feature = "nightly", non_exhaustive)]
+pub enum ThreescalersError {
+    // So far we don't have specific errors here.
+    #[snafu(display("Unknown threescalers error: {}", msg))]
+    Unknown { msg: String },
+    #[cfg(not(feature = "nightly"))]
+    #[doc(hidden)]
+    __Nonexhaustive,
+}
+
+// A general Result type that can yield a general API error
+pub type Result<T, E = ThreescalersError> = std::result::Result<T, E>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::all)]
-#![cfg_attr(feature = "nightly", feature(never_type))]
+#![cfg_attr(feature = "nightly", feature(never_type), feature(non_exhaustive))]
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
 #[cfg(all(test, feature = "nightly"))]
 extern crate test;
@@ -10,11 +10,13 @@ pub type Never = !;
 #[cfg(not(feature = "nightly"))]
 pub type Never = core::convert::Infallible;
 
+// Must come in first as it exposes macros and they are only available _after_ definition
+pub mod errors;
+
 pub mod api_call;
 pub mod application;
 pub mod credentials;
 pub mod encoding;
-pub mod errors;
 pub mod extensions;
 pub mod http;
 pub mod service;

--- a/src/user.rs
+++ b/src/user.rs
@@ -25,7 +25,7 @@ impl AsRef<str> for OAuthToken {
 
 // These trait impls provide a way to &str#parse()
 impl FromStr for UserId {
-    type Err = Error;
+    type Err = ThreescalersError;
 
     fn from_str(s: &str) -> Result<UserId> {
         Ok(UserId(s.to_owned()))
@@ -33,7 +33,7 @@ impl FromStr for UserId {
 }
 
 impl FromStr for OAuthToken {
-    type Err = Error;
+    type Err = ThreescalersError;
 
     fn from_str(s: &str) -> Result<OAuthToken> {
         Ok(OAuthToken(s.to_owned()))


### PR DESCRIPTION
This change replaces the existing error library with [snafu](https://docs.rs/snafu/0.1.4/snafu/) for custom error handling.

We previously were unwrapping calls to `parse()` but it seems that this is unrequited since these calls are infallible .