### PR TITLE
.travis.yml: use rustfmt from the stable toolchain only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,10 +106,13 @@ install:
 before_script:
   - |
       if [[ "$TRAVIS_RUST_VERSION" == "nightly" ]]; then
-        echo "--== [RUSTUP] Adding clippy & rustfmt ==--";
+        echo "--== [RUSTUP] Adding clippy ==--";
         if rustup component add clippy; then
           export CLIPPY=true;
         fi
+      fi
+      if [[ "$TRAVIS_RUST_VERSION" == "stable" ]]; then
+        echo "--== [RUSTUP] Adding rustfmt ==--";
         if rustup component add rustfmt; then
           export RUSTFMT=true;
         fi


### PR DESCRIPTION
The nightly one can vary wildly with regressions and turn PR's red
needing short-lived changes that in turn will fail when the
regressions are fixed. So use rustfmt as shipped with stable.