### PR TITLE
src/lib: feature(never_type) no longer required in nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![warn(clippy::all)]
 #![cfg_attr(feature = "nightly",
-            feature(never_type),
             feature(const_saturating_int_methods))]
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
 #[cfg(all(test, feature = "nightly"))]


### PR DESCRIPTION
It is stabilized for 1.41.0. It currently generates a warning in nightly.