### PR TITLE
examples: use [T]::iter() rather than [T]::into_iter()

### DIFF
--- a/examples/curl-easy-report.rs
+++ b/examples/curl-easy-report.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), threescalers::errors::Error> {
     let creds = Credentials::ServiceToken(ServiceToken::from("12[3]token"));
     let svc = Service::new("svc123", creds);
     let uks = ["userkey_1", "userkey_2", "userkey_3", "userkey 4", "userkey 5"];
-    let apps = uks.into_iter()
+    let apps = uks.iter()
                   .map(|uk| Application::from(UserKey::from(*uk)))
                   .collect::<Vec<_>>();
 

--- a/examples/curl-easy2-report.rs
+++ b/examples/curl-easy2-report.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), threescalers::errors::Error> {
     let creds = Credentials::ServiceToken(ServiceToken::from("12[3]token"));
     let svc = Service::new("svc123", creds);
     let uks = ["userkey_1", "userkey_2", "userkey_3", "userkey 4", "userkey 5"];
-    let apps = uks.into_iter()
+    let apps = uks.iter()
                   .map(|uk| Application::from(UserKey::from(*uk)))
                   .collect::<Vec<_>>();
 

--- a/examples/reqwest-report.rs
+++ b/examples/reqwest-report.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), threescalers::errors::Error> {
     let creds = Credentials::ServiceToken(ServiceToken::from("12[3]token"));
     let svc = Service::new("svc123", creds);
     let uks = ["userkey_1", "userkey_2", "userkey_3", "userkey 4", "userkey 5"];
-    let apps = uks.into_iter()
+    let apps = uks.iter()
                   .map(|uk| Application::from(UserKey::from(*uk)))
                   .collect::<Vec<_>>();
 


### PR DESCRIPTION
Such calls will likely create by-value iterators in the future, and
raise warnings in 1.41.0+.

See issue 66145 in rust-lang/rust.