### PR TITLE
Fix never_type with nightly

### DIFF
--- a/src/http/request/curl/easy.rs
+++ b/src/http/request/curl/easy.rs
@@ -46,11 +46,7 @@ impl<'easy, 'data> CurlEasyClient<'easy, 'data> {
     }
 
     pub fn easy(&self) -> Option<&'easy Easy> {
-        if let Self::Easy(e) = self {
-            Some(e)
-        } else {
-            None
-        }
+        if let Self::Easy(e) = self { Some(e) } else { None }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::all)]
 #![cfg_attr(feature = "nightly",
+            feature(never_type),
             feature(const_saturating_int_methods))]
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
 #[cfg(all(test, feature = "nightly"))]


### PR DESCRIPTION
The feature for never type had to be added. I think this has changed recently. ~The const saturating int methods feature is no longer needed in current nightlies.~

Signed-off-by: Peak Morgana <pm@pm.me>