### PR TITLE
Update to LF 6 and fix new instance of unrecognised Apache2/MIT title

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ before_install:
   - |
       if [[ "${LICENSE_FINDER}" == "true" ]]; then
         echo "--== [LICENSE_FINDER] Installing ==--" &&
-        gem install license_finder -v "= 5.10.2"
+        gem install license_finder -N -v "~> 6"
         echo "--== [LICENSE_FINDER] Running ==--" &&
         ci/license-check.sh
       fi

--- a/ci/dependency-decisions.yml
+++ b/ci/dependency-decisions.yml
@@ -56,37 +56,43 @@
 - - :permit
   - Unlicense
   - :who: 3scale Engineering
-    :why: Because it is valid
+    :why: License is valid
     :versions: []
     :when: 2019-08-27 13:48:47.000488000 Z
 - - :permit
   - BSL-1.0
   - :who: 3scale Engineering
-    :why: Because it is valid
+    :why: License is valid
     :versions: []
     :when: 2019-08-27 13:48:47.000488000 Z
 - - :permit
   - Unlicense OR MIT
   - :who: 3scale Engineering
-    :why: Both license are valid
+    :why: Both licenses are valid
     :versions: []
     :when: 2019-08-27 13:48:47.000488000 Z
 - - :permit
   - Apache-2.0 ,  MIT
   - :who: 3scale Engineering
-    :why: Both license are valid
+    :why: Both licenses are valid
     :versions: []
     :when: 2019-08-27 13:48:47.000488000 Z
 - - :permit
   - MIT OR Apache-2.0
   - :who: 3scale Engineering
-    :why: Both license are valid
+    :why: Both licenses are valid
+    :versions: []
+    :when: 2019-08-27 13:48:47.000488000 Z
+- - :permit
+  - Apache-2.0 OR MIT
+  - :who: 3scale Engineering
+    :why: Both licenses are valid
     :versions: []
     :when: 2019-08-27 13:48:47.000488000 Z
 - - :permit
   - Apache-2.0 OR BSL-1.0
   - :who: 3scale Engineering
-    :why: Both license are valid
+    :why: Both licenses are valid
     :versions: []
     :when: 2019-08-27 13:48:47.000488000 Z
 - - :approve

--- a/ci/dependency-decisions.yml
+++ b/ci/dependency-decisions.yml
@@ -1,89 +1,89 @@
 ---
-- - :whitelist
+- - :permit
   - MIT
   - :who: 3scale Engineering
     :why:
     :versions: []
     :when: 2016-08-16 09:25:15.635515271 Z
-- - :whitelist
+- - :permit
   - Apache 2.0
   - :who: 3scale Engineering
     :why:
     :versions: []
     :when: 2016-08-16 09:26:31.814319646 Z
-- - :whitelist
+- - :permit
   - Apache-2.0
   - :who: 3scale Engineering
     :why:
     :versions: []
     :when: 2016-08-16 09:26:31.814319646 Z
-- - :whitelist
+- - :permit
   - MIT-LICENSE
   - :who: 3scale Engineering
     :why: It's the same as MIT
     :versions: []
     :when: 2016-08-16 09:27:49.047135842 Z
-- - :whitelist
+- - :permit
   - BSD
   - :who: Jeff Kaufmann and Richard Fontana (Red Hat Legal)
     :why:
     :versions: []
     :when: 2016-11-23 11:02:51.564502000 Z
-- - :whitelist
+- - :permit
   - New BSD
   - :who: Jeff Kaufmann and Richard Fontana (Red Hat Legal)
     :why:
     :versions: []
     :when: 2016-11-23 11:03:04.247155000 Z
-- - :whitelist
+- - :permit
   - Simplified BSD
   - :who: Jeff Kaufmann and Richard Fontana (Red Hat Legal)
     :why:
     :versions: []
     :when: 2016-11-23 11:03:33.341497000 Z
-- - :whitelist
+- - :permit
   - LGPLv2+
   - :who: Jeff Kaufmann and Richard Fontana (Red Hat Legal)
     :why:
     :versions: []
     :when: 2016-11-23 11:04:13.584885000 Z
-- - :whitelist
+- - :permit
   - 2-clause BSDL
   - :who: Jeff Kaufmann and Richard Fontana (Red Hat Legal)
     :why:
     :versions: []
     :when: 2016-11-23 11:04:37.776089000 Z
-- - :whitelist
+- - :permit
   - Unlicense
   - :who: 3scale Engineering
     :why: Because it is valid
     :versions: []
     :when: 2019-08-27 13:48:47.000488000 Z
-- - :whitelist
+- - :permit
   - BSL-1.0
   - :who: 3scale Engineering
     :why: Because it is valid
     :versions: []
     :when: 2019-08-27 13:48:47.000488000 Z
-- - :whitelist
+- - :permit
   - Unlicense OR MIT
   - :who: 3scale Engineering
     :why: Both license are valid
     :versions: []
     :when: 2019-08-27 13:48:47.000488000 Z
-- - :whitelist
+- - :permit
   - Apache-2.0 ,  MIT
   - :who: 3scale Engineering
     :why: Both license are valid
     :versions: []
     :when: 2019-08-27 13:48:47.000488000 Z
-- - :whitelist
+- - :permit
   - MIT OR Apache-2.0
   - :who: 3scale Engineering
     :why: Both license are valid
     :versions: []
     :when: 2019-08-27 13:48:47.000488000 Z
-- - :whitelist
+- - :permit
   - Apache-2.0 OR BSL-1.0
   - :who: 3scale Engineering
     :why: Both license are valid


### PR DESCRIPTION
Fix issue with a new dependency in the tree that includes another variation of ASL2 and MIT. While at it upgrade to license finder 6.