### PR TITLE
Use references in usage

### DIFF
--- a/examples/curl-easy-report.rs
+++ b/examples/curl-easy-report.rs
@@ -36,9 +36,13 @@ fn main() -> Result<(), threescalers::errors::Error> {
                   ("metric41", 41),
                   ("metric42", 42),
                   ("metric51", 51),
-                  ("metric52", 52)].chunks(2)
-                                   .map(|metrics_and_values| Usage::new(metrics_and_values))
+                  ("metric52", 52)].iter()
+                                   .map(|m| (m.0, format!("{}", m.1)))
                                    .collect::<Vec<_>>();
+
+    let usages = usages.chunks(2)
+                       .map(|metrics_and_values| Usage::from(metrics_and_values))
+                       .collect::<Vec<_>>();
 
     println!("Usages: {:#?}", usages);
 

--- a/examples/curl-easy2-report.rs
+++ b/examples/curl-easy2-report.rs
@@ -35,9 +35,13 @@ fn main() -> Result<(), threescalers::errors::Error> {
                   ("metric41", 41),
                   ("metric42", 42),
                   ("metric51", 51),
-                  ("metric52", 52)].chunks(2)
-                                   .map(|metrics_and_values| Usage::new(metrics_and_values))
+                  ("metric52", 52)].iter()
+                                   .map(|m| (m.0, format!("{}", m.1)))
                                    .collect::<Vec<_>>();
+
+    let usages = usages.chunks(2)
+                       .map(|metrics_and_values| Usage::from(metrics_and_values))
+                       .collect::<Vec<_>>();
 
     println!("Usages: {:#?}", usages);
 

--- a/examples/reqwest-report.rs
+++ b/examples/reqwest-report.rs
@@ -37,9 +37,13 @@ fn main() -> Result<(), threescalers::errors::Error> {
                   ("metric41", 41),
                   ("metric42", 42),
                   ("metric51", 51),
-                  ("metric52", 52)].chunks(2)
-                                   .map(|metrics_and_values| Usage::new(metrics_and_values))
+                  ("metric52", 52)].iter()
+                                   .map(|m| (m.0, format!("{}", m.1)))
                                    .collect::<Vec<_>>();
+
+    let usages = usages.chunks(2)
+                       .map(|metrics_and_values| Usage::from(metrics_and_values))
+                       .collect::<Vec<_>>();
 
     println!("Usages: {:#?}", usages);
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -10,7 +10,7 @@ use super::{
 pub struct Transaction<'app, 'user, 'usage, 'ts> {
     application: &'app Application,
     user:        Option<&'user User>,
-    usage:       Option<&'usage Usage>,
+    usage:       Option<&'usage Usage<'usage>>,
     timestamp:   Option<&'ts Timestamp>,
 }
 

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -1,23 +1,26 @@
 use crate::ToParams;
 
 #[derive(Debug, Clone)]
-pub struct Usage {
-    metrics: Vec<(String, String)>,
+pub struct MetricUsage<'m>(&'m str, &'m str);
+
+impl<'m, M: AsRef<str> + 'm, V: AsRef<str> + 'm> From<&'m (M, V)> for MetricUsage<'m> {
+    fn from((m, v): &'m (M, V)) -> Self {
+        Self(m.as_ref(), v.as_ref())
+    }
 }
 
-// TODO fix this to stop the wild cloning of strings
-// IMO we should treat Usage as a container itself and share it in multiple calls
-// ie.
-// let u = Usage::new();
-// u.push(("metric1", 10));
-// u.push(("metric2", 20));
-// We should also be able to cache the generated parameters, and turn into the inner container,
-// clone, iterate, etc.
-// An internal Vec should do, as we are unlikely to need direct access to specific entries once we
-// have a usage (we can do it anyway, but searching sequentially). If we needed something more
-// powerful we can always write conversions from Vec/HashMap to Usage.
-impl Usage {
-    /// Creates a `Usage`.
+#[derive(Debug, Clone)]
+pub struct Usage<'m>(Vec<MetricUsage<'m>>);
+
+impl<'m, M: AsRef<str> + 'm, V: AsRef<str> + 'm> From<&'m [(M, V)]> for Usage<'m> {
+    fn from(mvs: &'m [(M, V)]) -> Self {
+        Self(mvs.iter().map(|mv| MetricUsage::from(mv)).collect())
+    }
+}
+
+// Add just enough to be able to access the inner vector for any modifications
+impl<'m> Usage<'m> {
+    /// Creates a `Usage` using the `From` implementation.
     ///
     /// # Examples
     ///
@@ -25,32 +28,43 @@ impl Usage {
     /// use threescalers::usage::*;
     ///
     /// let mut metrics = Vec::new();
-    /// metrics.push(("metric1", 10));
-    /// metrics.push(("metric2", 20));
-    /// let usage = Usage::new(&metrics);
+    /// metrics.push(("metric1", "10"));
+    /// metrics.push(("metric2", "20"));
+    /// let usage = Usage::new(metrics.as_slice());
     /// ```
-    pub fn new<T1: ToString, T2: ToString>(metrics: &[(T1, T2)]) -> Self {
-        let string_metrics = metrics.iter()
-                                    .map(|&(ref metric, ref value)| (metric.to_string(), value.to_string()))
-                                    .collect();
+    pub fn new<M: AsRef<str> + 'm, V: AsRef<str> + 'm>(mv: &'m [(M, V)]) -> Self {
+        Self::from(mv)
+    }
 
-        Self { metrics: string_metrics, }
+    /// Consumes the Usage and returns the underlying vector containing metric-value references.
+    pub fn into_inner(self) -> Vec<MetricUsage<'m>> {
+        self.0
+    }
+
+    /// Read access to the underlying vector containing metric-value references.
+    pub fn as_vec(&self) -> &Vec<MetricUsage<'m>> {
+        self.0.as_ref()
+    }
+
+    /// Exclusive access to the underlying vector containing metric-value references.
+    pub fn as_mut_vec(&mut self) -> &mut Vec<MetricUsage<'m>> {
+        self.0.as_mut()
     }
 }
 
 use std::borrow::Cow;
 
-impl<'k, 'v, 'this, E> ToParams<'k, 'v, 'this, E> for Usage
+impl<'k, 'v, 'this, E> ToParams<'k, 'v, 'this, E> for Usage<'this>
     where 'this: 'k + 'v,
           E: Extend<(Cow<'k, str>, &'v str)>
 {
     fn to_params_with_mangling<F: FnMut(Cow<'k, str>) -> Cow<'k, str>>(&'this self,
                                                                        extendable: &mut E,
                                                                        key_mangling: &mut F) {
-        extendable.extend(self.metrics.iter().map(|&(ref metric, ref value)| {
-                                                 let m = format!("usage[{}]", metric.as_str());
-                                                 (key_mangling(m.into()), value.as_str())
-                                             }))
+        extendable.extend(self.0.iter().map(|mv| {
+                                           let m = format!("usage[{}]", mv.0);
+                                           (key_mangling(m.into()), mv.1)
+                                       }))
     }
 }
 
@@ -59,7 +73,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn can_be_transformed_into_params() {
+    fn to_params_from_array() {
+        let metric1_name = "metric1";
+        let metric1_val = "10";
+        let metric2_name = "metric2";
+        let metric2_val = "20";
+        let metrics = [(metric1_name, metric1_val), (metric2_name, metric2_val)];
+        let usage = Usage::from(metrics.as_ref());
+
+        let mut result = Vec::new();
+        usage.to_params(&mut result);
+
+        let expected: Vec<(Cow<str>, &str)> = vec![("usage[metric1]".into(), metric1_val),
+                                                   ("usage[metric2]".into(), metric2_val),];
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn to_params_from_slice() {
         let metric1_name = "metric1";
         let metric1_val = "10";
         let metric2_name = "metric2";
@@ -67,7 +98,7 @@ mod tests {
         let mut metrics = Vec::new();
         metrics.push((metric1_name, metric1_val));
         metrics.push((metric2_name, metric2_val));
-        let usage = Usage::new(&metrics);
+        let usage = Usage::from(metrics.as_slice());
 
         let mut result = Vec::new();
         usage.to_params(&mut result);


### PR DESCRIPTION
Hi, since it is mentioned in comments I implemented usages module without the cloning. Feel free to ignore if not useful. I exposed an inner tuple struct and added methods to access it but could be kept private. Then I changed a few tests and the example code.

I think it is interesting to do this for a `no_std` version, do you plan to support it?