### PR TITLE
Cargo.toml,src/encoding: update to percent_encoding 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ nightly = []
 
 [dependencies]
 error-chain = "^0.12"
-percent-encoding = "^1"
+percent-encoding = "^2"
 http_types = { version = "^0.2", package = "http" }
 reqwest = { version = "^0.10", optional = true }
 curl = { version = "^0.4", optional = true }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -1,13 +1,18 @@
 use percent_encoding::{
-    define_encode_set,
     utf8_percent_encode,
-    PATH_SEGMENT_ENCODE_SET,
+    AsciiSet,
+    CONTROLS,
 };
 use std::borrow::Cow;
 
-define_encode_set! {
-    pub APISONATOR_EXTENSION_ENCODE_SET = [PATH_SEGMENT_ENCODE_SET] | { ';', '&', '=', '[', ']' }
-}
+const QUERY_ENCODE_SET: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'#').add(b'<').add(b'>');
+const DEFAULT_ENCODE_SET: &AsciiSet = &QUERY_ENCODE_SET.add(b'`').add(b'?').add(b'{').add(b'}');
+const PATH_SEGMENT_ENCODE_SET: &AsciiSet = &DEFAULT_ENCODE_SET.add(b'%').add(b'/');
+const APISONATOR_EXTENSION_ENCODE_SET: &AsciiSet = &PATH_SEGMENT_ENCODE_SET.add(b';')
+                                                                           .add(b'&')
+                                                                           .add(b'=')
+                                                                           .add(b'[')
+                                                                           .add(b']');
 
 pub fn encode(s: &str) -> Cow<str> {
     utf8_percent_encode(s, APISONATOR_EXTENSION_ENCODE_SET).into()


### PR DESCRIPTION
We have defined the corresponding encoding sets used in version 1. The initial `QUERY_ENCODE_SET` is based on the [upgrading guide](https://github.com/servo/rust-url/blob/f091d2b45b79958f9a40e2b98b844f75df6723de/UPGRADING.md#upgrading-from-percent-encoding-1x-to-2x) for the updated crate.