### PR TITLE
http,reqwest: update to http 0.2 and reqwest 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ http-types = []
 # Add in conversions for reqwest's crate types
 reqwest-types = ["reqwest"]
 reqwest-async = ["reqwest-types"]
-reqwest-sync = ["reqwest-types"]
+reqwest-sync = ["reqwest-types", "reqwest/blocking"]
 reqwest-all = ["reqwest-async", "reqwest-sync"]
 # Add in conversions for curl's crate types
 curl-types = ["curl"]
@@ -47,8 +47,8 @@ nightly = []
 [dependencies]
 error-chain = "^0.12"
 percent-encoding = "^1"
-http_types = { version = "^0.1", package = "http" }
-reqwest = { version = "^0.9", optional = true }
+http_types = { version = "^0.2", package = "http" }
+reqwest = { version = "^0.10", optional = true }
 curl = { version = "^0.4", optional = true }
 serde = { version = "^1", optional = true, features = ["derive"] }
 serde-xml-rs = { version = "^0.3", optional = true }

--- a/examples/reqwest-report.rs
+++ b/examples/reqwest-report.rs
@@ -12,7 +12,7 @@ use threescalers::{
     usage::Usage,
 };
 
-use reqwest::{
+use reqwest::blocking::{
     Client,
     RequestBuilder,
     Response,
@@ -88,7 +88,8 @@ fn show_response(res: Result<Response, reqwest::Error>) -> Result<Response, reqw
     match res {
         Ok(mut response) => {
             println!("*** SUCCESS ***\n{:#?}", response);
-            let jsonval = response.json::<serde_json::Value>().unwrap();
+            // Response#json consumes the response in reqwest 0.10+, so use serde_json directly
+            let jsonval = serde_json::from_reader::<&mut Response, serde_json::Value>(&mut response).unwrap();
             println!("*** BODY ***\n{}",
                      serde_json::to_string_pretty(&jsonval).unwrap());
             Ok(response)

--- a/src/http/request/http.rs
+++ b/src/http/request/http.rs
@@ -12,7 +12,7 @@ impl From<Request> for HTTPRequest<String> {
     fn from(r: Request) -> Self {
         let (uri, body) = r.parameters.uri_and_body(r.path);
         let body = body.unwrap_or("").to_owned();
-        let mut rb = HTTPRequest::builder();
+        let rb = HTTPRequest::builder();
 
         rb.header("User-Agent", USER_AGENT)
           .method(r.method)

--- a/src/http/request/reqwest.rs
+++ b/src/http/request/reqwest.rs
@@ -29,6 +29,6 @@ macro_rules! reqwest_impl {
 }
 
 #[cfg(feature = "reqwest-async")]
-reqwest_impl!(reqwest::r#async::Client, reqwest::r#async::RequestBuilder);
-#[cfg(feature = "reqwest-sync")]
 reqwest_impl!(reqwest::Client, reqwest::RequestBuilder);
+#[cfg(feature = "reqwest-sync")]
+reqwest_impl!(reqwest::blocking::Client, reqwest::blocking::RequestBuilder);


### PR DESCRIPTION
The two need to move at once since reqwest uses some HTTP types. Additionally, the async client is now the default, and the sync one moved under the `blocking` namespace.

Another minor change we needed to do was using `serde_json` explicitly to parse the response without consuming it in the Reqwest example.