### PR TITLE
#[no_std] compat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ maintenance = { status = "actively-developed" }
 default = ["std", "xml-response"]
 
 # Use std library
-std = ["no-std-compat/std"]
+std = ["no-std-compat/std", "anyhow/std"]
 # Add in conversions for http's crate types
 http-types = ["http_types"]
 # Add in conversions for reqwest's crate types
@@ -54,6 +54,7 @@ serde = { version = "^1", optional = true, default-features = false, features = 
 serde-xml-rs = { version = "^0.4", optional = true }
 chrono = { version = "^0.4", optional = true, default-features = false }
 no-std-compat = { version = "^0.4", features = ["alloc"] }
+anyhow = { version = "^1", default-features = false }
 
 [build-dependencies]
 rustc_version = "^0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,10 @@ codecov = { repository = "3scale-rs/threescalers" }
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["xml-response"]
+default = ["std", "xml-response"]
 
+# Use std library
+std = ["no-std-compat/std"]
 # Add in conversions for http's crate types
 http-types = ["http_types"]
 # Add in conversions for reqwest's crate types
@@ -48,9 +50,10 @@ percent-encoding = "^2"
 http_types = { version = "^0.2", package = "http", optional = true }
 reqwest = { version = "^0.10", optional = true }
 curl = { version = "^0.4", optional = true }
-serde = { version = "^1", optional = true, features = ["derive"] }
+serde = { version = "^1", optional = true, default-features = false, features = ["alloc", "derive"] }
 serde-xml-rs = { version = "^0.4", optional = true }
-chrono = { version = "^0.4", optional = true }
+chrono = { version = "^0.4", optional = true, default-features = false }
+no-std-compat = { version = "^0.4", features = ["alloc"] }
 
 [build-dependencies]
 rustc_version = "^0.2"

--- a/src/api_call.rs
+++ b/src/api_call.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use crate::{
     application::Application,
     extensions::List,

--- a/src/api_call.rs
+++ b/src/api_call.rs
@@ -1,6 +1,11 @@
 use std::prelude::v1::*;
 
 use crate::{
+    anyhow,
+    Error,
+};
+
+use crate::{
     application::Application,
     extensions::List,
     service::Service,
@@ -10,8 +15,6 @@ use crate::{
 };
 
 use crate::ToParams;
-
-use std::error::Error;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Kind {
@@ -76,8 +79,8 @@ impl<'service, 'tx, 'app, 'user, 'usage, 'extensions>
         self
     }
 
-    pub fn build(&self) -> Result<ApiCall, Box<dyn Error>> {
-        let kind = self.kind.ok_or_else(|| "kind error".to_string())?;
+    pub fn build(&self) -> Result<ApiCall, Error> {
+        let kind = self.kind.ok_or_else(|| anyhow!("kind error"))?;
         Ok(ApiCall::new(kind,
                         self.service,
                         self.transactions,

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use crate::ToParams;
 
 use std::{

--- a/src/application.rs
+++ b/src/application.rs
@@ -2,10 +2,9 @@ use std::prelude::v1::*;
 
 use crate::ToParams;
 
-use std::{
-    error::Error,
-    str::FromStr,
-};
+use crate::Error;
+
+use std::str::FromStr;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct AppId(String);
@@ -43,7 +42,7 @@ impl AsRef<str> for OAuthToken {
 
 // These trait impls provide a way to &str#parse() our Application type
 impl FromStr for AppId {
-    type Err = Box<dyn Error>;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<AppId, Self::Err> {
         Ok(AppId(s.into()))
@@ -51,7 +50,7 @@ impl FromStr for AppId {
 }
 
 impl FromStr for AppKey {
-    type Err = Box<dyn Error>;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<AppKey, Self::Err> {
         Ok(AppKey(s.into()))
@@ -59,7 +58,7 @@ impl FromStr for AppKey {
 }
 
 impl FromStr for UserKey {
-    type Err = Box<dyn Error>;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<UserKey, Self::Err> {
         Ok(UserKey(s.into()))
@@ -67,7 +66,7 @@ impl FromStr for UserKey {
 }
 
 impl FromStr for OAuthToken {
-    type Err = Box<dyn Error>;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<OAuthToken, Self::Err> {
         Ok(OAuthToken(s.into()))

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use crate::ToParams;
 
 use std::{

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -2,10 +2,9 @@ use std::prelude::v1::*;
 
 use crate::ToParams;
 
-use std::{
-    error::Error,
-    str::FromStr,
-};
+use crate::Error;
+
+use std::str::FromStr;
 
 #[derive(Debug)]
 pub struct ProviderKey(String);
@@ -33,7 +32,7 @@ impl AsRef<str> for ServiceToken {
 
 // These trait impls provide a way to &str#parse()
 impl FromStr for ProviderKey {
-    type Err = Box<dyn Error>;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<ProviderKey, Self::Err> {
         Ok(ProviderKey(s.into()))
@@ -41,7 +40,7 @@ impl FromStr for ProviderKey {
 }
 
 impl FromStr for ServiceToken {
-    type Err = Box<dyn Error>;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<ServiceToken, Self::Err> {
         Ok(ServiceToken(s.into()))
@@ -146,7 +145,7 @@ impl AsRef<str> for ServiceId {
 }
 
 impl FromStr for ServiceId {
-    type Err = Box<dyn Error>;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<ServiceId, Self::Err> {
         Ok(ServiceId(s.into()))

--- a/src/extensions/extension.rs
+++ b/src/extensions/extension.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::borrow::Cow;
 
 #[non_exhaustive]

--- a/src/extensions/list.rs
+++ b/src/extensions/list.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::{
     borrow::Cow,
     iter::FromIterator,

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,4 +1,9 @@
-use std::collections::HashMap;
+use std::prelude::v1::*;
+
+use std::collections::{
+    btree_map::Iter as InnerIter,
+    BTreeMap,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -28,15 +33,16 @@ impl Method {
 
 #[derive(Debug, Clone, PartialEq)]
 #[repr(transparent)]
-pub struct HeaderMap(HashMap<String, String>);
+pub struct HeaderMap(BTreeMap<String, String>);
 
 impl HeaderMap {
     pub fn new() -> Self {
-        Self(HashMap::new())
+        Self(BTreeMap::new())
     }
 
-    pub fn with_capacity(cap: usize) -> Self {
-        Self(HashMap::with_capacity(cap))
+    // There's no provision for this method in the inner map
+    pub fn with_capacity(_: usize) -> Self {
+        Self::new()
     }
 
     pub fn insert(&mut self, key: String, value: String) -> Option<String> {
@@ -64,11 +70,11 @@ impl Default for HeaderMap {
 
 #[repr(transparent)]
 pub struct Iter<'a> {
-    iter: std::collections::hash_map::Iter<'a, String, String>,
+    iter: InnerIter<'a, String, String>,
 }
 
 impl<'a> Iterator for Iter<'a> {
-    type Item = <std::collections::hash_map::Iter<'a, String, String> as Iterator>::Item;
+    type Item = <InnerIter<'a, String, String> as Iterator>::Item;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
@@ -76,8 +82,8 @@ impl<'a> Iterator for Iter<'a> {
 }
 
 impl IntoIterator for HeaderMap {
-    type IntoIter = <HashMap<String, String> as IntoIterator>::IntoIter;
-    type Item = <HashMap<String, String> as IntoIterator>::Item;
+    type IntoIter = <BTreeMap<String, String> as IntoIterator>::IntoIter;
+    type Item = <BTreeMap<String, String> as IntoIterator>::Item;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -101,8 +107,8 @@ impl<S: ToString> Extend<(S, S)> for HeaderMap {
     }
 }
 
-impl From<HashMap<String, String>> for HeaderMap {
-    fn from(map: HashMap<String, String>) -> Self {
+impl From<BTreeMap<String, String>> for HeaderMap {
+    fn from(map: BTreeMap<String, String>) -> Self {
         HeaderMap(map)
     }
 }

--- a/src/http/parameters.rs
+++ b/src/http/parameters.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use super::Method;
 use std::borrow::Cow;
 

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use crate::{
     api_call::{
         Kind::*,

--- a/src/http/request/curl.rs
+++ b/src/http/request/curl.rs
@@ -23,12 +23,11 @@ impl TryFrom<&HeaderMap> for List {
 
 // Common functions for curl clients
 pub fn copy_data(offset: &mut usize, source: &[u8], dst: &mut [u8]) -> usize {
-    use std::io::Read;
-
-    let mut bytes = &source[*offset..];
-    let newcount = bytes.read(dst).expect("error while copying body data to buffer");
-    *offset += newcount;
-    newcount
+    let bytes = &source[*offset..];
+    let len = bytes.len();
+    dst[..len].copy_from_slice(bytes);
+    *offset += len;
+    len
 }
 
 #[cfg(feature = "curl-easy")]

--- a/src/http/request/curl.rs
+++ b/src/http/request/curl.rs
@@ -3,10 +3,11 @@ use std::prelude::v1::*;
 use curl::easy::List;
 
 use super::HeaderMap;
+use crate::Error;
 use core::convert::TryFrom;
 
 impl TryFrom<&HeaderMap> for List {
-    type Error = Box<dyn std::error::Error>;
+    type Error = Error;
 
     fn try_from(hm: &HeaderMap) -> Result<Self, Self::Error> {
         let mut list = List::new();

--- a/src/http/request/curl.rs
+++ b/src/http/request/curl.rs
@@ -3,8 +3,11 @@ use std::prelude::v1::*;
 use curl::easy::List;
 
 use super::HeaderMap;
+use crate::{
+    anyhow,
+    Error,
+};
 use core::convert::TryFrom;
-use crate::{anyhow, Error};
 
 impl TryFrom<&HeaderMap> for List {
     type Error = Error;
@@ -14,7 +17,8 @@ impl TryFrom<&HeaderMap> for List {
 
         for (k, v) in hm.iter() {
             let header = [k.as_str(), ": ", v.as_str()].concat();
-            list.append(header.as_str()).map_err(|e| anyhow!("failed to add a node to a curl List: {:#?}", e))?;
+            list.append(header.as_str())
+                .map_err(|e| anyhow!("failed to add a node to a curl List: {:#?}", e))?;
         }
 
         Ok(list)

--- a/src/http/request/curl.rs
+++ b/src/http/request/curl.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use curl::easy::List;
 
 use super::HeaderMap;

--- a/src/http/request/curl.rs
+++ b/src/http/request/curl.rs
@@ -3,8 +3,8 @@ use std::prelude::v1::*;
 use curl::easy::List;
 
 use super::HeaderMap;
-use crate::Error;
 use core::convert::TryFrom;
+use crate::{anyhow, Error};
 
 impl TryFrom<&HeaderMap> for List {
     type Error = Error;
@@ -14,7 +14,7 @@ impl TryFrom<&HeaderMap> for List {
 
         for (k, v) in hm.iter() {
             let header = [k.as_str(), ": ", v.as_str()].concat();
-            list.append(header.as_str())?;
+            list.append(header.as_str()).map_err(|e| anyhow!("failed to add a node to a curl List: {:#?}", e))?;
         }
 
         Ok(list)

--- a/src/http/request/curl/easy.rs
+++ b/src/http/request/curl/easy.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use super::super::{
     Method,
     Request,

--- a/src/http/request/curl/easy.rs
+++ b/src/http/request/curl/easy.rs
@@ -1,6 +1,6 @@
 use std::prelude::v1::*;
 
-use crate::Error;
+use crate::{anyhow, Error};
 
 use super::super::{
     Method,
@@ -74,25 +74,25 @@ impl<'easy, 'data, URI: ToString> SetupRequest<'easy, URI, Result<CurlEasyClient
             Method::PUT => self.put(true),
             // any other verb needs to use custom_request()
             m => self.custom_request(m.as_str()),
-        }?;
+        }.map_err(|e| anyhow!("failed to set curl request method: {:#?}", e))?;
 
-        self.url(uri.as_str())?;
-        let mut headerlist = List::try_from(&r.headers)?;
+        self.url(uri.as_str()).map_err(|e| anyhow!("failed to set curl request URL: {:#?}", e))?;
+        let mut headerlist = List::try_from(&r.headers).map_err(|e| anyhow!("failed to create curl::List from headers: {:#?}", e))?;
         // libcurl by default adds "Expect: 100-continue" to send bodies, which would break us
-        headerlist.append("Expect:")?;
+        headerlist.append("Expect:").map_err(|e| anyhow!("failed to add node to curl::List: {:#?}", e))?;
         // don't specify Content-Type for this request (similar to other clients)
-        headerlist.append("Content-Type:")?;
-        self.http_headers(headerlist)?;
+        headerlist.append("Content-Type:").map_err(|e| anyhow!("failed to add node to curl::List: {:#?}", e))?;
+        self.http_headers(headerlist).map_err(|e| anyhow!("failed to add headers to curl client: {:#?}", e))?;
 
         Ok(match body {
             Some(_) => {
                 let body = r.parameters.into_inner();
                 // this sets the Content-Length - some servers will misbehave without this
-                self.post_field_size(body.len() as u64)?;
+                self.post_field_size(body.len() as u64).map_err(|e| anyhow!("failed to set Content-Length: {:#?}", e))?;
                 let mut transfer = self.transfer();
 
                 let mut count = 0usize;
-                transfer.read_function(move |buf| Ok(super::copy_data(&mut count, &body.as_bytes(), buf)))?;
+                transfer.read_function(move |buf| Ok(super::copy_data(&mut count, &body.as_bytes(), buf))).map_err(|e| anyhow!("failed to set curl client read function: {:#?}", e))?;
 
                 transfer.into()
             }

--- a/src/http/request/curl/easy.rs
+++ b/src/http/request/curl/easy.rs
@@ -1,5 +1,7 @@
 use std::prelude::v1::*;
 
+use crate::Error;
+
 use super::super::{
     Method,
     Request,
@@ -53,13 +55,13 @@ impl<'easy, 'data> CurlEasyClient<'easy, 'data> {
     }
 }
 
-impl<'easy, 'data, URI: ToString>
-    SetupRequest<'easy, URI, Result<CurlEasyClient<'easy, 'data>, Box<dyn std::error::Error>>> for Easy
+impl<'easy, 'data, URI: ToString> SetupRequest<'easy, URI, Result<CurlEasyClient<'easy, 'data>, Error>>
+    for Easy
 {
     fn setup_request(&'easy mut self,
                      r: Request,
                      params: URI)
-                     -> Result<CurlEasyClient<'easy, 'data>, Box<dyn std::error::Error>> {
+                     -> Result<CurlEasyClient<'easy, 'data>, Error> {
         use core::convert::TryFrom;
 
         let (uri, body) = r.parameters.uri_and_body(r.path);

--- a/src/http/request/curl/easy2.rs
+++ b/src/http/request/curl/easy2.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use super::super::{
     Method,
     Request,

--- a/src/http/request/curl/easy2.rs
+++ b/src/http/request/curl/easy2.rs
@@ -1,5 +1,7 @@
 use std::prelude::v1::*;
 
+use crate::Error;
+
 use super::super::{
     Method,
     Request,
@@ -73,8 +75,8 @@ impl SetBody for BodyHandle {
     }
 }
 
-impl<URI: ToString, H: SetBody> SetupRequest<'_, URI, Result<(), Box<dyn std::error::Error>>> for Easy2<H> {
-    fn setup_request(&mut self, r: Request, params: URI) -> Result<(), Box<dyn std::error::Error>> {
+impl<URI: ToString, H: SetBody> SetupRequest<'_, URI, Result<(), Error>> for Easy2<H> {
+    fn setup_request(&mut self, r: Request, params: URI) -> Result<(), Error> {
         use core::convert::TryFrom;
 
         let (uri, body) = r.parameters.uri_and_body(r.path);

--- a/src/http/request/curl/easy2.rs
+++ b/src/http/request/curl/easy2.rs
@@ -1,6 +1,6 @@
 use std::prelude::v1::*;
 
-use crate::Error;
+use crate::{anyhow, Error, Result};
 
 use super::super::{
     Method,
@@ -89,20 +89,20 @@ impl<URI: ToString, H: SetBody> SetupRequest<'_, URI, Result<(), Error>> for Eas
             Method::PUT => self.put(true),
             // any other verb needs to use custom_request()
             m => self.custom_request(m.as_str()),
-        }?;
+        }.map_err(|e| anyhow!("failed to set curl request method: {:#?}", e))?;
 
-        self.url(uri.as_str())?;
-        let mut headerlist = List::try_from(&r.headers)?;
+        self.url(uri.as_str()).map_err(|e| anyhow!("failed to set curl request URL: {:#?}", e))?;
+        let mut headerlist = List::try_from(&r.headers).map_err(|e| anyhow!("failed to create curl::List from headers: {:#?}", e))?;
         // libcurl by default adds "Expect: 100-continue" to send bodies, which would break us
-        headerlist.append("Expect:")?;
+        headerlist.append("Expect:").map_err(|e| anyhow!("failed to add node to curl::List: {:#?}", e))?;
         // don't specify Content-Type for this request (similar to other clients)
-        headerlist.append("Content-Type:")?;
-        self.http_headers(headerlist)?;
+        headerlist.append("Content-Type:").map_err(|e| anyhow!("failed to add node to curl::List: {:#?}", e))?;
+        self.http_headers(headerlist).map_err(|e| anyhow!("failed to add headers to curl client: {:#?}", e))?;
 
         if body.is_some() {
             let body = r.parameters.into_inner();
             // this sets the Content-Length - some servers will misbehave without this
-            self.post_field_size(body.len() as u64)?;
+            self.post_field_size(body.len() as u64).map_err(|e| anyhow!("failed to set Content-Length: {:#?}", e))?;
 
             self.get_mut().set_body(body);
         }

--- a/src/http/request/curl/easy2.rs
+++ b/src/http/request/curl/easy2.rs
@@ -1,6 +1,10 @@
 use std::prelude::v1::*;
 
-use crate::{anyhow, Error, Result};
+use crate::{
+    anyhow,
+    Error,
+    Result,
+};
 
 use super::super::{
     Method,
@@ -91,18 +95,26 @@ impl<URI: ToString, H: SetBody> SetupRequest<'_, URI, Result<(), Error>> for Eas
             m => self.custom_request(m.as_str()),
         }.map_err(|e| anyhow!("failed to set curl request method: {:#?}", e))?;
 
-        self.url(uri.as_str()).map_err(|e| anyhow!("failed to set curl request URL: {:#?}", e))?;
-        let mut headerlist = List::try_from(&r.headers).map_err(|e| anyhow!("failed to create curl::List from headers: {:#?}", e))?;
+        self.url(uri.as_str())
+            .map_err(|e| anyhow!("failed to set curl request URL: {:#?}", e))?;
+        let mut headerlist =
+            List::try_from(&r.headers).map_err(|e| {
+                                          anyhow!("failed to create curl::List from headers: {:#?}", e)
+                                      })?;
         // libcurl by default adds "Expect: 100-continue" to send bodies, which would break us
-        headerlist.append("Expect:").map_err(|e| anyhow!("failed to add node to curl::List: {:#?}", e))?;
+        headerlist.append("Expect:")
+                  .map_err(|e| anyhow!("failed to add node to curl::List: {:#?}", e))?;
         // don't specify Content-Type for this request (similar to other clients)
-        headerlist.append("Content-Type:").map_err(|e| anyhow!("failed to add node to curl::List: {:#?}", e))?;
-        self.http_headers(headerlist).map_err(|e| anyhow!("failed to add headers to curl client: {:#?}", e))?;
+        headerlist.append("Content-Type:")
+                  .map_err(|e| anyhow!("failed to add node to curl::List: {:#?}", e))?;
+        self.http_headers(headerlist)
+            .map_err(|e| anyhow!("failed to add headers to curl client: {:#?}", e))?;
 
         if body.is_some() {
             let body = r.parameters.into_inner();
             // this sets the Content-Length - some servers will misbehave without this
-            self.post_field_size(body.len() as u64).map_err(|e| anyhow!("failed to set Content-Length: {:#?}", e))?;
+            self.post_field_size(body.len() as u64)
+                .map_err(|e| anyhow!("failed to set Content-Length: {:#?}", e))?;
 
             self.get_mut().set_body(body);
         }

--- a/src/http/request/http_types.rs
+++ b/src/http/request/http_types.rs
@@ -6,6 +6,7 @@ use super::{
 use crate::{
     api_call::ApiCall,
     version::*,
+    Error,
 };
 use core::convert::TryFrom;
 use http_types::{
@@ -42,7 +43,7 @@ trait FillFrom {
 }
 
 impl FillFrom for HTTPHeaderMap {
-    type Error = Box<dyn std::error::Error>;
+    type Error = Error;
 
     fn fill_from(&mut self, hm: &HeaderMap) -> Result<(), Self::Error> {
         use core::str::FromStr;
@@ -59,7 +60,7 @@ impl FillFrom for HTTPHeaderMap {
 }
 
 impl TryFrom<HeaderMap> for HTTPHeaderMap {
-    type Error = Box<dyn std::error::Error>;
+    type Error = Error;
 
     fn try_from(hm: HeaderMap) -> Result<Self, Self::Error> {
         let mut map = HTTPHeaderMap::with_capacity(hm.len());
@@ -71,7 +72,7 @@ impl TryFrom<HeaderMap> for HTTPHeaderMap {
 }
 
 impl TryFrom<Request> for HTTPRequest<String> {
-    type Error = Box<dyn std::error::Error>;
+    type Error = Error;
 
     fn try_from(r: Request) -> Result<Self, Self::Error> {
         let (uri, body) = r.parameters.uri_and_body(r.path);
@@ -91,7 +92,7 @@ impl TryFrom<Request> for HTTPRequest<String> {
 }
 
 impl TryFrom<&ApiCall<'_, '_, '_, '_, '_, '_>> for HTTPRequest<String> {
-    type Error = Box<dyn std::error::Error>;
+    type Error = Error;
 
     fn try_from(i: &ApiCall) -> Result<Self, Self::Error> {
         HTTPRequest::try_from(Request::from(i))

--- a/src/http/request/reqwest.rs
+++ b/src/http/request/reqwest.rs
@@ -11,8 +11,8 @@ macro_rules! reqwest_impl {
         //
         // https://a_host
         //
-        impl<URI: ToString> SetupRequest<'_, URI, Result<$B, Box<dyn std::error::Error>>> for $C {
-            fn setup_request(&mut self, r: Request, params: URI) -> Result<$B, Box<dyn std::error::Error>> {
+        impl<URI: ToString> SetupRequest<'_, URI, Result<$B, Error>> for $C {
+            fn setup_request(&mut self, r: Request, params: URI) -> Result<$B, Error> {
                 use core::convert::TryInto;
 
                 let (uri, body) = r.parameters.uri_and_body(r.path);

--- a/src/http/request/reqwest.rs
+++ b/src/http/request/reqwest.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use super::{
     Request,
     SetupRequest,

--- a/src/http/request/reqwest.rs
+++ b/src/http/request/reqwest.rs
@@ -4,6 +4,10 @@ use super::{
     Request,
     SetupRequest,
 };
+use crate::{
+    anyhow,
+    Error,
+};
 
 macro_rules! reqwest_impl {
     { $C:ty, $B:ty } => {
@@ -19,7 +23,9 @@ macro_rules! reqwest_impl {
                 let uri_base = params;
                 let uri = uri_base.to_string() + uri.as_ref();
 
-                let rb = self.request(r.method.into(), uri.as_str()).headers(r.headers.try_into()?);
+                let rb = self.request(r.method.into(), uri.as_str())
+                    .headers(r.headers.try_into()
+                             .map_err(|e| anyhow!("failed to add headers to reqwest: {:#?}", e))?);
 
                 Ok(match body {
                     // when there is a body just consume it from the request's

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,10 @@
 #![cfg_attr(feature_gate_const_saturating_int_methods,
             feature(const_saturating_int_methods))]
 #![cfg_attr(feature_gate_test, feature(test))]
+#![no_std]
+extern crate no_std_compat as std;
+use std::prelude::v1::*;
+
 #[cfg(all(test, has_test))]
 extern crate test;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,19 @@ pub mod version;
 #[cfg(feature = "xml-response")]
 pub mod response;
 
+pub(crate) mod error {
+    pub use anyhow::{
+        anyhow,
+        Error,
+        Result,
+    };
+}
+
+pub use error::Error;
+
+#[allow(unused_imports)]
+pub(crate) use error::anyhow;
+
 use std::borrow::Cow;
 
 /// This is the trait to be implemented by structures that can set parameters to API calls.

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use chrono::prelude::*;
 use serde::{
     de::{

--- a/src/response.rs
+++ b/src/response.rs
@@ -12,11 +12,11 @@ use serde::{
 };
 use std::{
     collections::{
-        hash_map::{
+        btree_map::{
             Iter,
             IterMut,
         },
-        HashMap,
+        BTreeMap,
     },
     fmt,
     str::FromStr,
@@ -38,14 +38,14 @@ mod systemtime {
 
 pub use systemtime::PeriodTime;
 
-// We might want to consider moving from a BTreeMap to a Vec, as most of the time this hashmap will
+// We might want to consider moving from a BTreeMap to a Vec, as most of the time this btreemap will
 // contain a (very) small number of entries.
 #[derive(Debug, Clone, PartialEq, Default)]
-pub struct MetricsHierarchy(HashMap<String, Vec<String>>);
+pub struct MetricsHierarchy(BTreeMap<String, Vec<String>>);
 
 impl MetricsHierarchy {
     pub fn new() -> Self {
-        Self(HashMap::new())
+        Self(BTreeMap::new())
     }
 
     pub fn insert<S: Into<String>, V: Into<Vec<String>>>(&mut self,
@@ -67,7 +67,7 @@ impl MetricsHierarchy {
         self.0.iter_mut()
     }
 
-    pub fn into_inner(self) -> HashMap<String, Vec<String>> {
+    pub fn into_inner(self) -> BTreeMap<String, Vec<String>> {
         self.0
     }
 
@@ -225,7 +225,7 @@ impl<'de> Visitor<'de> for MetricsHierarchyVisitor {
         // The key in the hierarchy structure is always "metric". It is not
         // used, but we need to read it to get the value.
         while map.next_key::<String>()?.is_some() {
-            let val: HashMap<String, String> = map.next_value()?;
+            let val: BTreeMap<String, String> = map.next_value()?;
 
             let parent_metric = val["name"].to_owned();
             let children_metrics = val["children"].split(' ')

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use crate::{
     credentials::{
         Credentials,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use super::{
     application::Application,
     usage::Usage,

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use crate::ToParams;
 
 #[derive(Debug, Clone)]

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use crate::ToParams;
 
 use std::{

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,11 +1,11 @@
 use std::prelude::v1::*;
 
-use crate::ToParams;
-
-use std::{
-    error::Error,
-    str::FromStr,
+use crate::{
+    Error,
+    ToParams,
 };
+
+use std::str::FromStr;
 
 #[derive(Debug)]
 pub struct UserId(String);
@@ -27,7 +27,7 @@ impl AsRef<str> for OAuthToken {
 
 // These trait impls provide a way to &str#parse()
 impl FromStr for UserId {
-    type Err = Box<dyn Error>;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<UserId, Self::Err> {
         Ok(UserId(s.to_owned()))
@@ -35,7 +35,7 @@ impl FromStr for UserId {
 }
 
 impl FromStr for OAuthToken {
-    type Err = Box<dyn Error>;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<OAuthToken, Self::Err> {
         Ok(OAuthToken(s.to_owned()))


### PR DESCRIPTION
This adds support for `#[no_std]` assuming there is an allocator.

Errors are handled via `anyhow` because it's pretty close to `Box<dyn Error>` and has a `no_std` mode.

Some code using `HashMap` has been changed to use `BTreeMap` because the exact implementation has never been important and it allows us to not depend on another crate in no_std.