### PR TITLE
Use a flag-based system for features and fix nightly

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,151 @@
-// Detect nightly compilers.
+// Detect nightly compilers and features.
 use rustc_version::{
     version_meta,
     Channel,
+    Version,
+    VersionMeta,
 };
 
-fn main() {
-    if version_meta().unwrap().channel == Channel::Nightly {
-        println!("cargo:rustc-cfg=feature=\"nightly\"");
+use AvailabilityStatic::*;
+
+// Declare features used by the project.
+// Use minimum and maximum (not included) versions.
+// "always"/"unknown" for minimum and "unknown" for maximum are special.
+static FEATURES: &'static [Feature<'_>] = &[Feature { name:         "nightly",
+                                                      availability: Nightly("always", "unknown"), },
+                                            Feature { name:         "test",
+                                                      availability: NightlyGated("always", "unknown"), },
+                                            Feature { name:         "never_type",
+                                                      availability: NightlyGated("1.12.0", "unknown"), },
+                                            Feature { name:         "const_saturating_int_methods",
+                                                      availability: Stable("1.47.0", "unknown"), }];
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let version_meta = version_meta()?;
+
+    FEATURES.iter()
+            .map(|f| f.cargo_flags(&version_meta))
+            .for_each(|fl_set| fl_set.iter().for_each(|fl| println!("{}", fl)));
+
+    Ok(())
+}
+
+// *** Supporting code below ***
+enum VersionSpec {
+    AlwaysSupported,
+    EqualOrGreater(Version),
+    Between(Version, Version),
+    Lower(Version),
+}
+
+impl VersionSpec {
+    pub fn matches(&self, version: &Version) -> bool {
+        use VersionSpec::*;
+
+        match self {
+            AlwaysSupported => true,
+            EqualOrGreater(req) => version >= req,
+            Lower(req) => version < req,
+            Between(reqmin, reqmax) => version >= reqmin && version < reqmax,
+        }
+    }
+}
+
+impl From<(&str, &str)> for VersionSpec {
+    fn from((min, top): (&str, &str)) -> VersionSpec {
+        let min_v = Version::parse(min);
+        let top_v = Version::parse(top);
+
+        match (min, top) {
+            ("unknown", "unknown") | ("always", "unknown") => VersionSpec::AlwaysSupported,
+            ("unknown", _) | ("always", _) => VersionSpec::Lower(top_v.unwrap()),
+            (_, "unknown") => VersionSpec::EqualOrGreater(min_v.unwrap()),
+            (..) => VersionSpec::Between(min_v.unwrap(), top_v.unwrap()),
+        }
+    }
+}
+
+enum Availability {
+    Stable(VersionSpec),
+    Nightly(VersionSpec),
+    NightlyGated(VersionSpec),
+}
+
+enum FeatureFlags {
+    Unavailable,
+    HasFeature,
+    HasGatedFeature,
+}
+
+struct Feature<'a> {
+    name:         &'a str,
+    availability: AvailabilityStatic,
+}
+
+impl<'a> Feature<'a> {
+    pub fn name(&self) -> &str {
+        self.name
+    }
+
+    pub fn flags(&self, version_meta: &VersionMeta) -> FeatureFlags {
+        use Availability::*;
+
+        let version = &version_meta.semver;
+        let channel = version_meta.channel;
+
+        let availability = Availability::from(&self.availability);
+
+        match availability {
+            Stable(spec) if channel == Channel::Stable || channel == Channel::Beta => {
+                if spec.matches(version) {
+                    FeatureFlags::HasFeature
+                } else {
+                    FeatureFlags::Unavailable
+                }
+            }
+            Nightly(spec) if channel == Channel::Nightly => {
+                if spec.matches(version) {
+                    FeatureFlags::HasFeature
+                } else {
+                    FeatureFlags::Unavailable
+                }
+            }
+            NightlyGated(spec) if channel == Channel::Nightly => {
+                if spec.matches(version) {
+                    FeatureFlags::HasGatedFeature
+                } else {
+                    FeatureFlags::Unavailable
+                }
+            }
+            _ => FeatureFlags::Unavailable,
+        }
+    }
+
+    pub fn cargo_flags(&self, version_meta: &VersionMeta) -> Box<[String]> {
+        match self.flags(version_meta) {
+            FeatureFlags::HasFeature => [format!("cargo:rustc-cfg=has_{}", self.name())].into(),
+            FeatureFlags::HasGatedFeature => [format!("cargo:rustc-cfg=has_{}", self.name()),
+                                              format!("cargo:rustc-cfg=feature_gate_{}", self.name())].into(),
+            FeatureFlags::Unavailable => [].into(),
+        }
+    }
+}
+
+enum AvailabilityStatic {
+    Stable(&'static str, &'static str),
+    NightlyGated(&'static str, &'static str),
+    Nightly(&'static str, &'static str),
+}
+
+impl From<&AvailabilityStatic> for Availability {
+    fn from(avs: &AvailabilityStatic) -> Availability {
+        use Availability as Av;
+        use AvailabilityStatic::*;
+
+        match *avs {
+            Stable(min, top) => Av::Stable((min, top).into()),
+            Nightly(min, top) => Av::Nightly((min, top).into()),
+            NightlyGated(min, top) => Av::NightlyGated((min, top).into()),
+        }
     }
 }

--- a/src/http/parameters.rs
+++ b/src/http/parameters.rs
@@ -118,7 +118,7 @@ impl Parameters {
     }
 }
 
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(all(test, has_nightly))]
 mod benches {
     use super::*;
     use test::Bencher;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,14 @@
 #![warn(clippy::all)]
-#![cfg_attr(feature = "nightly",
-            feature(never_type),
-            feature(const_saturating_int_methods))]
-#![cfg_attr(all(test, feature = "nightly"), feature(test))]
-#[cfg(all(test, feature = "nightly"))]
+#![cfg_attr(feature_gate_never_type, feature(never_type))]
+#![cfg_attr(feature_gate_const_saturating_int_methods, feature(const_saturating_int_methods))]
+#![cfg_attr(feature_gate_test, feature(test))]
+#[cfg(all(test, has_test))]
 extern crate test;
 
 // Define a never type useful for some traits (ie. SetupRequest)
-#[cfg(feature = "nightly")]
+#[cfg(feature_gate_never_type)]
 pub type Never = !;
-#[cfg(not(feature = "nightly"))]
+#[cfg(not(has_never_type))]
 pub type Never = core::convert::Infallible;
 
 pub mod api_call;

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -167,18 +167,30 @@ mod tests {
         const MIN_HARD: TimestampOffsetInt =
             [TimestampOffsetInt::min_value() + 1, 0][UNSIGNED_VALUES as usize];
 
-        #[cfg(feature = "nightly")]
-        const MAX_SECS: TimestampOffsetInt =
-            (TimestampOffsetInt::max_value() / RESOLUTION).saturating_sub(MAX_0_UNIX_EPOCH_DIFFERENTIAL);
-        #[cfg(not(feature = "nightly"))]
-        const MAX_SECS: TimestampOffsetInt =
-            (TimestampOffsetInt::max_value() / RESOLUTION) - MAX_0_UNIX_EPOCH_DIFFERENTIAL;
+        #[cfg(has_const_saturating_int_methods)]
+        mod maxmin_secs {
+            use super::*;
 
-        #[cfg(feature = "nightly")]
-        const MIN_SECS: TimestampOffsetInt =
-            (MIN_HARD / RESOLUTION).saturating_add(MIN_0_UNIX_EPOCH_DIFFERENTIAL);
-        #[cfg(not(feature = "nightly"))]
-        const MIN_SECS: TimestampOffsetInt = (MIN_HARD / RESOLUTION) + MIN_0_UNIX_EPOCH_DIFFERENTIAL;
+            pub const MAX_SECS: TimestampOffsetInt =
+                (TimestampOffsetInt::max_value() / RESOLUTION).saturating_sub(MAX_0_UNIX_EPOCH_DIFFERENTIAL);
+            pub const MIN_SECS: TimestampOffsetInt =
+                (MIN_HARD / RESOLUTION).saturating_add(MIN_0_UNIX_EPOCH_DIFFERENTIAL);
+        }
+
+        #[cfg(not(has_const_saturating_int_methods))]
+        mod maxmin_secs {
+            use super::*;
+
+            pub const MAX_SECS: TimestampOffsetInt =
+                (TimestampOffsetInt::max_value() / RESOLUTION) - MAX_0_UNIX_EPOCH_DIFFERENTIAL;
+
+            pub const MIN_SECS: TimestampOffsetInt = (MIN_HARD / RESOLUTION) + MIN_0_UNIX_EPOCH_DIFFERENTIAL;
+        }
+
+        pub use maxmin_secs::{
+            MAX_SECS,
+            MIN_SECS,
+        };
 
         pub const fn unix_epoch_offset_as_secs() -> TimestampOffsetInt {
             SECONDS_TO_UNIX_EPOCH


### PR DESCRIPTION
Nightlies are currently breaking because we call `feature(...)` on them for a feature that was just stabilised.

With this PR we fix nightlies _and_ we also enable that feature for versions of Rust 1.47.0+ while keeping previous versions working.