### PR TITLE
Release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Notable changes to threescalers will be tracked in this document.
 
+## 0.6.1 - 2020-10-08
+
+### Compatibility
+
+- This release is again usable with newer (and hopefully older) nightlies and makes
+  use of new facilities on 1.47.0. ([#70](https://github.com/3scale-rs/threescalers/pull/70))
+
 ## 0.6.0 - 2020-05-03
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2018"
 name = "threescalers"
 description = "3scale API client library for Rust"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Alejandro Martinez Ruiz <alex@flawedcode.org>", "David Ortiz Lopez <z.david.ortiz@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/3scale-rs/threescalers"


### PR DESCRIPTION
This release is mostly about fixing the library to work on nightly compilers.