### PR TITLE
Cargo.toml: update serde-xml-rs to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ http_types = { version = "^0.2", package = "http" }
 reqwest = { version = "^0.10", optional = true }
 curl = { version = "^0.4", optional = true }
 serde = { version = "^1", optional = true, features = ["derive"] }
-serde-xml-rs = { version = "^0.3", optional = true }
+serde-xml-rs = { version = "^0.4", optional = true }
 chrono = { version = "^0.4", optional = true }
 
 [build-dependencies]


### PR DESCRIPTION
Dependency update introducing a *breaking change* due to a different error type returned when parsing authorizations.