### PR TITLE
Mapping rules implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ codecov = { repository = "3scale-rs/threescalers" }
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["std", "xml-response"]
+default = ["std", "xml-response", "rest-mappings"]
 
 # Use std library
-std = ["no-std-compat/std", "anyhow/std"]
+std = ["no-std-compat/std", "anyhow/std", "regex/std"]
 # Add in conversions for http's crate types
 http-types = ["http_types"]
 # Add in conversions for reqwest's crate types
@@ -41,6 +41,9 @@ curl-all = ["curl-easy", "curl-easy2"]
 all-types = ["http-types", "reqwest-all", "curl-all"]
 # Response parsing
 xml-response = ["serde-xml-rs", "serde", "chrono"]
+# HTTP mapping rules
+rest-mappings = ["regex", "lazy_static"]
+rest-mappings-serde = ["serde"]
 
 [dependencies]
 percent-encoding = "^2"
@@ -52,6 +55,9 @@ serde-xml-rs = { version = "^0.4", optional = true }
 chrono = { version = "^0.4", optional = true, default-features = false }
 no-std-compat = { version = "^0.4", features = ["alloc"] }
 anyhow = { version = "^1", default-features = false }
+regex = { version = "^1", optional = true, default-features = false, features = ["perf"] }
+# lazy_static has a "negative" no_std flag rather than an additive "std" flag :/
+lazy_static = { version = "^1", optional = true, default-features = false, features = ["spin_no_std"] }
 
 [build-dependencies]
 autocfg = { git = "https://github.com/unleashed/autocfg", branch = "probe_feature" }
@@ -70,3 +76,5 @@ required-features = ["curl-easy2"]
 
 [dev-dependencies]
 serde_json = "^1.0"
+itertools = "^0.10"
+rand = "^0.8"

--- a/src/http.rs
+++ b/src/http.rs
@@ -118,3 +118,6 @@ pub use self::parameters::Parameters;
 pub mod endpoints;
 pub mod request;
 pub use self::request::Request;
+
+#[cfg(feature = "rest-mappings")]
+pub mod mapping_rule;

--- a/src/http/mapping_rule.rs
+++ b/src/http/mapping_rule.rs
@@ -1,0 +1,303 @@
+// This module implements HTTP mapping rules as casually specified in the 3scale documentation.
+//
+// There _are_ differences with how Apicast behaves, just because the description of what
+// the rules do and don't isn't precise, and some existing behavior depend on the underlying
+// regular expression engine. So consider this an approximation that we might want to limit
+// or expand over time.
+use std::prelude::v1::*;
+
+use regex::Regex;
+
+#[cfg(feature = "rest-mappings-serde")]
+mod serde_impl;
+
+mod method;
+pub use method::Method;
+
+mod escaping;
+
+#[derive(Debug)]
+pub enum HttpLineError {
+    ParsingError,
+}
+
+#[derive(Debug, Clone)]
+pub struct RestRule {
+    method: Method,
+    path: Regex,
+    qs: Option<Vec<Regex>>,
+}
+
+impl RestRule {
+    pub fn new<M: Into<Method>, S: AsRef<str>>(
+        method: M,
+        path_n_qs: S,
+    ) -> Result<Self, escaping::Error> {
+        let (path, qs) = escaping::split_path_n_qs(path_n_qs.as_ref());
+
+        Self::with_path_n_qs(method, path, qs)
+    }
+
+    pub fn with_path_n_qs<M: Into<Method>, S: AsRef<str>>(
+        method: M,
+        path: S,
+        qs: Option<S>,
+    ) -> Result<Self, escaping::Error> {
+        let path = escaping::path_regex(path.as_ref())?;
+        let qs = qs
+            .map(|qs| escaping::query_string_regex(qs.as_ref()))
+            .transpose()?;
+
+        Ok(Self {
+            method: method.into(),
+            path,
+            qs,
+        })
+    }
+
+    pub fn matches<S: AsRef<str>>(&self, method: &Method, path_qs: S) -> bool {
+        method == &self.method && self.matches_path_with_qs(path_qs)
+    }
+
+    pub fn matches_request_line<S: AsRef<str>>(
+        &self,
+        http_request_line: S,
+    ) -> Result<bool, HttpLineError> {
+        let mut it = http_request_line.as_ref().splitn(3, ' ').take(2);
+        let method = Method::from(it.next().ok_or(HttpLineError::ParsingError)?);
+        let path_n_qs = it.next().ok_or(HttpLineError::ParsingError)?;
+
+        Ok(self.matches(&method, path_n_qs))
+    }
+
+    pub fn matches_path_n_qs<S: AsRef<str>>(&self, path: S, qs: Option<S>) -> bool {
+        self.qs
+            .as_deref()
+            .map(|qs_regexes| {
+                let mut kvs = qs
+                    .as_ref()
+                    .map(AsRef::as_ref)
+                    .unwrap_or("")
+                    .split('&')
+                    .collect::<Vec<_>>();
+
+                qs_regexes.iter().all(|regex| {
+                    kvs.iter()
+                        .enumerate()
+                        .find_map(
+                            |(idx, &kv)| {
+                                if regex.is_match(kv) {
+                                    Some(idx)
+                                } else {
+                                    None
+                                }
+                            },
+                        )
+                        .map(|idx| {
+                            kvs.remove(idx);
+                            true
+                        })
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(true)
+            && self
+                .path
+                .is_match(escaping::coalesce_chars(path.as_ref(), '/').as_str())
+    }
+
+    pub fn matches_path_with_qs<S: AsRef<str>>(&self, path_qs: S) -> bool {
+        let (path, qs) = escaping::split_path_n_qs(path_qs.as_ref());
+
+        self.matches_path_n_qs(path, qs)
+    }
+
+    pub fn method(&self) -> &Method {
+        &self.method
+    }
+
+    // String form of the path + query string pattern
+    pub fn pattern(&self) -> String {
+        let mut pattern = self.path.as_str()[2..].replace(escaping::PATH_VALUE_REGEX_S, "{_}");
+
+        if let Some(qs) = self.qs.as_deref() {
+            let mut qs = qs
+                .iter()
+                .map(|kv| kv.as_str().replace(escaping::QS_VALUE_REGEX_S, "{_}"));
+
+            if let Some(first) = qs.next() {
+                pattern.push('?');
+                pattern.push_str(&first.as_str()[2..]);
+
+                pattern = qs.fold(pattern, |mut acc, re| {
+                    acc.push('&');
+                    acc.push_str(&re.as_str()[2..]);
+                    acc
+                });
+            }
+        }
+
+        pattern
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use helpers::random_method;
+
+    mod helpers {
+        use super::Method;
+        use rand::prelude::SliceRandom as _;
+
+        pub fn random_method() -> Method {
+            [
+                Method::Any,
+                Method::GET,
+                Method::HEAD,
+                Method::POST,
+                Method::CONNECT,
+                Method::DELETE,
+                Method::OPTIONS,
+                Method::PUT,
+                Method::TRACE,
+                Method::PATCH,
+                Method::Other("future_method".into()),
+            ]
+            .choose(&mut rand::thread_rng())
+            .unwrap()
+            .clone()
+        }
+    }
+
+    #[test]
+    fn match_simple_case() -> Result<(), escaping::Error> {
+        let method = random_method();
+        let mr = RestRule::new(method.clone(), "/?required=1")?;
+
+        assert!(mr
+            .matches_request_line(
+                format!(
+                    "{} {} HTTP/1.1",
+                    method.as_str(),
+                    "/test?optional=1&required=1&other=1"
+                )
+                .as_str()
+            )
+            .unwrap(),);
+
+        Ok(())
+    }
+
+    #[test]
+    fn match_simple_cases() -> Result<(), escaping::Error> {
+        let mr = RestRule::new(Method::Any, "/")?;
+
+        let path_w_qs = [
+            ("/", true),
+            ("/?", true),
+            ("/?a", true),
+            ("/?a=", true),
+            ("/?a=1", true),
+            ("/?a=1&", true),
+            ("/?a=1&b=2", true),
+            ("/some/path", true),
+            ("/some/path/", true),
+            ("/some/path/?a=1&b=2", true),
+        ];
+
+        for (pnqs, expected) in path_w_qs.iter() {
+            let (path, qs) = escaping::split_path_n_qs(pnqs);
+            let method = helpers::random_method();
+
+            assert_eq!(mr.matches(&method, pnqs), *expected);
+            assert_eq!(mr.matches_path_with_qs(pnqs), *expected);
+            assert_eq!(mr.matches_path_n_qs(path, qs), *expected);
+            assert_eq!(
+                mr.matches_request_line(format!("{} {} HTTP/1.1", method.as_str(), pnqs).as_str())
+                    .unwrap(),
+                *expected
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn match_edge_cases() -> Result<(), escaping::Error> {
+        let path_n_qs = "/auto?maybe_empty=&w=hello&color={color}";
+        let mr = RestRule::new("any", path_n_qs)?;
+
+        let path_w_qs = [
+            ("/", false),
+            ("/auto", false),
+            ("/auto?", false),
+            ("/auto?w=hello&color=red&maybe_empty", false),
+            ("/auto?w=hello&color=red&maybe_empty=", true),
+            ("/auto-matic?w=hello&maybe_empty=&color=green", true),
+            ("/auto?maybe_empty=its-full-now&color=blue&w=hello", true),
+            ("/auto-matic?color=black&w=hello&maybe_empty=&", true),
+            ("/auto-matic?w=hello&color&maybe_empty=", false),
+        ];
+
+        for (pnqs, expected) in path_w_qs.iter() {
+            let (path, qs) = escaping::split_path_n_qs(pnqs);
+            let method = helpers::random_method();
+
+            assert_eq!(mr.matches(&method, pnqs), *expected);
+            assert_eq!(mr.matches_path_with_qs(pnqs), *expected);
+            assert_eq!(mr.matches_path_n_qs(path, qs), *expected);
+            assert_eq!(
+                mr.matches_request_line(format!("{} {} HTTP/1.1", method.as_str(), pnqs).as_str())
+                    .unwrap(),
+                *expected
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn match_combined_cases() -> Result<(), escaping::Error> {
+        use itertools::Itertools as _;
+
+        let args = [r"fmt={fmt}", r"l{an}g={code}", r"s=1", r"t=$9"];
+
+        for permutation in args.iter().permutations(args.len()) {
+            let qs = permutation.iter().join("&");
+            let path_n_qs = format!("{}?{}", r"/abc/v{version}/id\$$", qs);
+            let mr = RestRule::new("aNY", path_n_qs.as_str())?;
+
+            let path_w_qs = [
+                ("/abc/v1/id$?fmt=html&lang=ca&s=1&t=$9", true),
+                ("///abc/v1//id$?fmt=html&lang=ca&s=1&t=$9", true),
+                ("/abc/v1/v2/id$?fmt=html&lang=ca&s=1&t=$9", false),
+                ("/abc/v1./id$?fmt=html&lang=ca&other=70&s=1&z=2&t=$9", true),
+                ("/abc//v2/id$?misc=1&t=$9&fmt=html&z=2&s=1&leng=en", true),
+                ("/abc/v2/id$?misc=1&t=$998&fmt=html&z=2&s=1&l.g=ca", true),
+                ("/abc/v1.1/id$?missing_required_params=1", false),
+                ("/abc/v1/id$?fmt=html&lang=ca&other=70&s=2&z=1&t=$9", false),
+                ("/abc/v1/id$?fmt=json&lang=ca&other=70&z=2", false),
+                ("/abc/v1/id?fmt=json&lang=ca&other=70&s=1&z=2&t=$9", false),
+            ];
+
+            for (pnqs, expected) in path_w_qs.iter() {
+                let (path, qs) = escaping::split_path_n_qs(pnqs);
+                let method = helpers::random_method();
+
+                assert_eq!(mr.matches(&method, pnqs), *expected);
+                assert_eq!(mr.matches_path_with_qs(pnqs), *expected);
+                assert_eq!(mr.matches_path_n_qs(path, qs), *expected);
+                assert_eq!(
+                    mr.matches_request_line(
+                        format!("{} {} HTTP/1.1", method.as_str(), pnqs).as_str()
+                    )
+                    .unwrap(),
+                    *expected
+                );
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/http/mapping_rule/escaping.rs
+++ b/src/http/mapping_rule/escaping.rs
@@ -1,0 +1,283 @@
+#[cfg(not(has_core_iter_Iterator_reduce))]
+use crate::util::compat::features::IteratorFoldSelfExt as _;
+use std::prelude::v1::*;
+
+use regex::Regex;
+
+#[derive(Debug)]
+pub enum Error {
+    // Error working with or trying to build a regex
+    RegexError(regex::Error),
+    // Memory requirements too big
+    RegexTooBig,
+}
+
+impl From<regex::Error> for Error {
+    fn from(e: regex::Error) -> Self {
+        Self::RegexError(e)
+    }
+}
+
+// Regex to use when finding a placeholder in a path rule.
+pub(super) const PATH_VALUE_REGEX_S: &str = r"[0-9a-zA-Z_\-.~%!$&'()*+,;=@:]+";
+// Same for query string, but this one just avoids the ampersand character.
+pub(super) const QS_VALUE_REGEX_S: &str = r"[0-9a-zA-Z_\-.~%!$'()*+,;=@:]+";
+// Implicit anchor to start of string used in these expressions.
+pub(super) const START_RE: &str = r"\A";
+
+// The regular expression that defines how a placeholder looks.
+lazy_static::lazy_static! {
+    // panic: this literal string is a valid regular expression, so won't panic.
+    static ref PLACEHOLDER_REGEX: Regex = Regex::new(r"\{.+?\}").unwrap();
+}
+
+#[cfg_attr(not(has_core_iter_Iterator_reduce), allow(unstable_name_collisions))]
+pub(super) fn query_string_regex(s: &str) -> Result<Vec<Regex>, Error> {
+    let kv_regex_s = PLACEHOLDER_REGEX
+        .split(s)
+        .map(|literal| {
+            literal
+                .split('&')
+                .map(|part| regex::escape(part))
+                .reduce(|mut acc, escaped_part| {
+                    acc.push('&');
+                    acc.push_str(escaped_part.as_str());
+                    acc
+                })
+                // panic: can't panic because String::split always return 1 or more elements in the iterator, so reduce always returns Some()
+                .unwrap()
+        })
+        .reduce(|mut acc, escaped| {
+            acc.push_str(QS_VALUE_REGEX_S);
+            acc.push_str(escaped.as_str());
+            acc
+        })
+        // panic: can't panic because Regex::split always return 1 or more elements in the iterator, so reduce always returns Some()
+        .unwrap();
+
+    let mut kv_iter = kv_regex_s.split('&');
+
+    kv_iter.try_fold(
+        Vec::with_capacity(core::cmp::max(kv_iter.size_hint().0, 8)),
+        |mut acc, kv_literal| {
+            let mut kv = START_RE.to_string();
+            kv.push_str(kv_literal);
+            Regex::new(kv.as_str())
+                .map(|regex| {
+                    acc.push(regex);
+                    acc
+                })
+                .map_err(Error::from)
+        },
+    )
+}
+
+// Apicast path matching rule
+//
+// 1. Remove duplicate '/'s from the given pattern because nginx (maybe
+//    others?) removes them.
+// 2. Take _anything_ in between characters { } _lazily_ and replace with a
+//    regex that takes a superset of alphanumeric characters.
+// 3. Ensure that a terminating $ character means an exact match. (ie. don't
+//    escape the remaining literal text)
+#[cfg_attr(not(has_core_iter_Iterator_reduce), allow(unstable_name_collisions))]
+pub(super) fn path_regex(path: &str) -> Result<Regex, Error> {
+    let path_without_dup_fslashes = coalesce_chars(path, '/');
+    let regex_literal = PLACEHOLDER_REGEX
+        .split(path_without_dup_fslashes.as_str())
+        .map(|literal| literal.to_string()) // No regex escaping!
+        .reduce(|mut acc, literal| {
+            acc.push_str(PATH_VALUE_REGEX_S);
+            acc.push_str(literal.as_str());
+            acc
+        })
+        // panic: can't panic because Regex::split always return 1 or more elements in the iterator, so reduce always returns Some()
+        .unwrap();
+
+    let required_capacity = regex_literal
+        .len()
+        .checked_add(START_RE.len())
+        .ok_or(Error::RegexTooBig)?;
+
+    let mut final_regex = String::with_capacity(required_capacity);
+
+    final_regex.push_str(START_RE);
+    final_regex.push_str(&regex_literal);
+
+    Ok(Regex::new(final_regex.as_str())?)
+}
+
+pub(super) fn split_path_n_qs(s: &str) -> (&str, Option<&str>) {
+    s.find('?')
+        .map(|idx| (&s[..idx], Some(&s[idx + 1..])))
+        .unwrap_or((s, None))
+}
+
+pub(super) fn coalesce_chars(s: &str, coalescing_char: char) -> String {
+    enum Last {
+        Missed,
+        Matched,
+    }
+
+    let mut last = Last::Missed;
+
+    s.chars()
+        .fold(String::with_capacity(s.len()), |mut acc, c| {
+            if c == coalescing_char {
+                if let Last::Missed = last {
+                    acc.push(c);
+                    last = Last::Matched;
+                }
+            } else {
+                acc.push(c);
+                last = Last::Missed;
+            }
+
+            acc
+        })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    mod coalesce_chars {
+        use super::*;
+
+        #[test]
+        fn remove_duped_forward_slashes() -> Result<(), Error> {
+            let pattern = "/a//b///c////d/////e/";
+            assert_eq!(coalesce_chars(pattern, '/').as_str(), "/a/b/c/d/e/");
+
+            Ok(())
+        }
+    }
+
+    mod split_path_n_qs {
+        use super::*;
+
+        #[test]
+        fn strips_question_mark() -> Result<(), Error> {
+            let pattern = "/abc?param1=1&param2=2";
+            let (path, qs) = split_path_n_qs(pattern);
+
+            assert_eq!(path, "/abc");
+            assert_eq!(qs, Some("param1=1&param2=2"));
+
+            Ok(())
+        }
+    }
+
+    mod query_string_regex {
+        use super::*;
+
+        #[test]
+        fn builds_correct_qs_param_regexes() -> Result<(), Error> {
+            let qs_patterns = "fmt={fmt}&hardcoded=1&lang{num}={lang}";
+            let regexes = query_string_regex(qs_patterns)?;
+            let regexes_s = regexes.iter().map(Regex::as_str).collect::<Vec<_>>();
+
+            assert!(regexes_s.contains(&format!(r"{}fmt={}", START_RE, QS_VALUE_REGEX_S).as_str()));
+            assert!(regexes_s.contains(&format!(r"{}hardcoded=1", START_RE).as_str()));
+            assert!(regexes_s.contains(
+                &format!(r"{s}lang{qs}={qs}", s = START_RE, qs = QS_VALUE_REGEX_S).as_str()
+            ));
+
+            Ok(())
+        }
+
+        #[test]
+        fn matches_qs_parameters() -> Result<(), Error> {
+            let qs_patterns = ["fmt={fmt}", "hardcoded=1", "lang{num}={lang}"];
+            let qs_examples = ["fmt=json", "hardcoded=1", "lang_1=ca"];
+            let qs_counter_ex = ["fmt-json", "hardcoded=", "a_lang_1=ca"];
+
+            let regexes = query_string_regex(qs_patterns.join("&").as_str())?;
+
+            for regex in regexes {
+                assert!(qs_examples.iter().any(|&qs| { regex.is_match(qs) }));
+                assert!(qs_counter_ex.iter().all(|&qs| { !regex.is_match(qs) }));
+            }
+
+            Ok(())
+        }
+    }
+
+    mod path_regex {
+        use super::*;
+
+        #[test]
+        fn match_fail() -> Result<(), Error> {
+            let pattern = "/abc";
+            let regex = path_regex(pattern)?;
+
+            assert!(!regex.is_match("/aaa"));
+
+            Ok(())
+        }
+
+        #[test]
+        fn match_prefix() -> Result<(), Error> {
+            let pattern = "/abc";
+            let regex = path_regex(pattern)?;
+
+            assert!(regex.is_match("/abc"));
+            assert!(regex.is_match("/abcd"));
+
+            Ok(())
+        }
+
+        #[test]
+        fn match_special_chars() -> Result<(), Error> {
+            let pattern = "/foo/{wildcard}/bar";
+            let regex = path_regex(pattern)?;
+
+            assert!(regex.is_match("/foo/a@b/bar"));
+            assert!(regex.is_match("/foo/a:b/bar"));
+            assert!(regex.is_match("/foo/a%b/bar"));
+            assert!(regex.is_match("/foo/a$b/bar"));
+            assert!(regex.is_match("/foo/a()b/bar"));
+
+            Ok(())
+        }
+
+        #[test]
+        fn match_exact() -> Result<(), Error> {
+            let pattern = "/abc$";
+            let regex = path_regex(pattern)?;
+
+            assert!(regex.is_match("/abc"));
+            assert!(!regex.is_match("/abcd"));
+
+            Ok(())
+        }
+
+        #[test]
+        fn match_dollar_sign_at_end() -> Result<(), Error> {
+            let pattern = r"/abc\$";
+            let regex = path_regex(pattern)?;
+
+            assert!(regex.is_match("/abc$"));
+            assert!(!regex.is_match("/abcd"));
+
+            Ok(())
+        }
+
+        #[test]
+        fn match_double_forward_slashes() -> Result<(), Error> {
+            let patterns = [
+                ("/foo//bar", "/foo/bar"),
+                ("/foo///bar", "/foo/bar"),
+                ("///foo///bar///", "/foo/bar/"),
+                ("/foo/bar///", "/foo/bar/"),
+                ("/foo/ /bar", "/foo/ /bar"),
+            ];
+            for (pattern, expected) in patterns.iter() {
+                let regex = path_regex(pattern)?;
+                assert!(regex.is_match(expected));
+            }
+
+            Ok(())
+        }
+    }
+}

--- a/src/http/mapping_rule/method.rs
+++ b/src/http/mapping_rule/method.rs
@@ -1,0 +1,204 @@
+use std::prelude::v1::*;
+
+#[cfg(feature = "rest-mappings-serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::util::string::AllCaps;
+
+#[cfg_attr(
+    feature = "rest-mappings-serde",
+    derive(Serialize, Deserialize),
+    serde(from = "String", into = "String")
+)]
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Debug, Clone)]
+pub enum Method {
+    GET,
+    HEAD,
+    POST,
+    PUT,
+    DELETE,
+    CONNECT,
+    OPTIONS,
+    TRACE,
+    PATCH,
+    Any,
+    Other(AllCaps),
+}
+
+impl From<&str> for Method {
+    fn from(s: &str) -> Self {
+        Self::from(AllCaps::from(s))
+    }
+}
+
+impl From<String> for Method {
+    fn from(s: String) -> Self {
+        Self::from(AllCaps::from(s))
+    }
+}
+
+impl From<AllCaps> for Method {
+    fn from(s: AllCaps) -> Self {
+        match s.as_str() {
+            "ANY" => Self::Any,
+            "GET" => Self::GET,
+            "HEAD" => Self::HEAD,
+            "POST" => Self::POST,
+            "PUT" => Self::PUT,
+            "DELETE" => Self::DELETE,
+            "CONNECT" => Self::CONNECT,
+            "OPTIONS" => Self::OPTIONS,
+            "TRACE" => Self::TRACE,
+            "PATCH" => Self::PATCH,
+            _ => Self::Other(s),
+        }
+    }
+}
+
+impl From<Method> for String {
+    fn from(m: Method) -> Self {
+        match m {
+            // specialize the Other case as it is already a String
+            Method::Other(s) => s.into(),
+            _ => m.as_str().into(),
+        }
+    }
+}
+
+impl PartialEq for Method {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Any, _) | (_, Self::Any) => true,
+            (Self::Other(a), Self::Other(b)) => a == b,
+            (Self::GET, Self::GET)
+            | (Self::HEAD, Self::HEAD)
+            | (Self::POST, Self::POST)
+            | (Self::PUT, Self::PUT)
+            | (Self::DELETE, Self::DELETE)
+            | (Self::CONNECT, Self::CONNECT)
+            | (Self::OPTIONS, Self::OPTIONS)
+            | (Self::TRACE, Self::TRACE)
+            | (Self::PATCH, Self::PATCH) => true,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for Method {}
+
+impl Method {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Method::Any => "ANY",
+            Method::GET => "GET",
+            Method::HEAD => "HEAD",
+            Method::POST => "POST",
+            Method::PUT => "PUT",
+            Method::DELETE => "DELETE",
+            Method::CONNECT => "CONNECT",
+            Method::OPTIONS => "OPTIONS",
+            Method::TRACE => "TRACE",
+            Method::PATCH => "PATCH",
+            Method::Other(s) => s.as_str(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use fixtures::all_methods;
+
+    mod fixtures {
+        use super::*;
+
+        pub fn all_methods() -> Box<[Method]> {
+            Box::new([
+                Method::GET,
+                Method::HEAD,
+                Method::POST,
+                Method::PUT,
+                Method::DELETE,
+                Method::CONNECT,
+                Method::OPTIONS,
+                Method::TRACE,
+                Method::PATCH,
+                Method::Other("future_method".into()),
+            ])
+        }
+    }
+
+    #[test]
+    fn any_matches_every_other_method() {
+        let method = Method::from("any");
+
+        for other in all_methods().iter() {
+            assert_eq!(&method, other);
+        }
+    }
+
+    #[test]
+    fn other_only_matches_exact_other() {
+        let method = Method::from("future_method");
+
+        assert_ne!(method, Method::Other("other_future_method".into()));
+
+        let all_methods = all_methods();
+        let other = all_methods
+            .iter()
+            .filter(|&m| m == &method)
+            .collect::<Vec<_>>();
+        assert_eq!(other.len(), 1);
+
+        assert_eq!(&method, other[0]);
+    }
+
+    #[test]
+    fn equality_and_identity() {
+        let all_methods = all_methods();
+        for (idx, method) in all_methods.iter().enumerate() {
+            // create a list of all methods except the currently processed by index (ie. not using ==)
+            let other_methods: Vec<_> = all_methods
+                .iter()
+                .enumerate()
+                .filter(|(oidx, _)| idx != *oidx)
+                .map(|(_, m)| m)
+                .cloned()
+                .collect();
+
+            // identity
+            assert_eq!(method, &all_methods[idx]);
+
+            for other_method in other_methods {
+                assert_ne!(method, &other_method);
+            }
+        }
+    }
+
+    #[test]
+    fn transitive_id_with_strings() {
+        for method in all_methods().iter() {
+            transitive_id_with_strings_check(method);
+        }
+    }
+
+    #[test]
+    fn transitive_id_with_method_any() {
+        assert_eq!(Method::Any.as_str(), "ANY");
+        assert_eq!(String::from(Method::Any), "ANY".to_string());
+        assert!(matches!(Method::from("ANY"), Method::Any));
+        assert!(matches!(Method::from("ANY".to_string()), Method::Any));
+
+        transitive_id_with_strings_check(&Method::Any);
+    }
+
+    fn transitive_id_with_strings_check(method: &Method) {
+        let string: String = method.clone().into();
+        let other_string_method: Method = string.into();
+        let other_str_method: Method = method.as_str().into();
+
+        assert_eq!(method, &other_string_method);
+        assert_eq!(method, &other_str_method);
+    }
+}

--- a/src/http/mapping_rule/serde_impl.rs
+++ b/src/http/mapping_rule/serde_impl.rs
@@ -1,0 +1,171 @@
+use std::prelude::v1::*;
+
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+use super::{escaping, RestRule};
+
+fn convert_escaping_error<E: de::Error>(ee: escaping::Error) -> E {
+    match ee {
+        escaping::Error::RegexError(e) => de::Error::custom(format!("regex error: {}", e)),
+        escaping::Error::RegexTooBig => de::Error::custom("regex requires too much memory"),
+    }
+}
+
+impl<'de> Deserialize<'de> for RestRule {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(field_identifier, rename_all = "lowercase")]
+        enum Field {
+            Method,
+            Pattern,
+        }
+
+        struct MappingRuleVisitor;
+
+        impl<'de> de::Visitor<'de> for MappingRuleVisitor {
+            type Value = RestRule;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                formatter
+                    .write_str("a mapping rule with a method and a path and query string pattern")
+            }
+
+            fn visit_seq<V: de::SeqAccess<'de>>(self, mut seq: V) -> Result<RestRule, V::Error> {
+                let method: &str = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let pattern: &str = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                let mapping_rule =
+                    RestRule::new(method, pattern).map_err(convert_escaping_error)?;
+
+                Ok(mapping_rule)
+            }
+
+            fn visit_map<V: de::MapAccess<'de>>(self, mut map: V) -> Result<Self::Value, V::Error> {
+                let mut method = None;
+                let mut pattern = None;
+
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Method => {
+                            if method.is_some() {
+                                return Err(de::Error::duplicate_field("method"));
+                            }
+                            method = Some(map.next_value()?);
+                        }
+                        Field::Pattern => {
+                            if pattern.is_some() {
+                                return Err(de::Error::duplicate_field("pattern"));
+                            }
+                            pattern = Some(map.next_value()?);
+                        }
+                    }
+                }
+                let method: &str = method.ok_or_else(|| de::Error::missing_field("method"))?;
+                let pattern: &str = pattern.ok_or_else(|| de::Error::missing_field("pattern"))?;
+
+                let mapping_rule =
+                    RestRule::new(method, pattern).map_err(convert_escaping_error)?;
+
+                Ok(mapping_rule)
+            }
+        }
+
+        deserializer.deserialize_struct("MappingRule", &["method", "pattern"], MappingRuleVisitor)
+    }
+}
+
+impl Serialize for RestRule {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+
+        let mut state = serializer.serialize_struct("MappingRule", 2)?;
+        state.serialize_field("method", self.method().as_str())?;
+        state.serialize_field("pattern", self.pattern().as_str())?;
+        state.end()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use fixtures::JSON;
+
+    mod fixtures {
+        pub(super) const JSON: &str = r#"{
+            "method": "get",
+            "pattern": "//some/{product}/id?n={id}&order=asc"
+        }"#;
+    }
+
+    #[test]
+    fn deserialize() -> Result<(), serde_json::Error> {
+        let mapping_rule: RestRule = serde_json::from_str(JSON)?;
+
+        assert_eq!(mapping_rule.method().as_str(), "GET");
+
+        let path_pattern = mapping_rule.path.as_str();
+        let path_expected = format!(
+            r"{}/some/{}/id",
+            super::escaping::START_RE,
+            super::escaping::PATH_VALUE_REGEX_S
+        );
+
+        assert_eq!(path_pattern, path_expected.as_str());
+
+        let qs_pattern = mapping_rule.qs.as_ref();
+        assert!(qs_pattern.is_some());
+
+        let qs_pattern = qs_pattern
+            .unwrap()
+            .iter()
+            .map(regex::Regex::to_string)
+            .collect::<Vec<_>>()
+            .join("&");
+
+        let qs_expected = format!(
+            r"{start_re}n={qs_re}&{start_re}order=asc",
+            start_re = super::escaping::START_RE,
+            qs_re = super::escaping::QS_VALUE_REGEX_S
+        );
+
+        assert_eq!(qs_pattern.as_str(), qs_expected.as_str());
+
+        Ok(())
+    }
+
+    #[test]
+    fn serialize() -> Result<(), serde_json::Error> {
+        use regex::Regex;
+
+        let mapping_rule = RestRule::new("get", "///some/{product}//id$?n={id}&order=asc").unwrap();
+        let json = serde_json::to_string(&mapping_rule)?;
+
+        let other: RestRule = serde_json::from_str(json.as_str())?;
+        assert_eq!(mapping_rule.method(), other.method());
+        assert_eq!(mapping_rule.pattern(), other.pattern());
+        assert_eq!(
+            mapping_rule
+                .qs
+                .as_ref()
+                .unwrap()
+                .iter()
+                .map(Regex::as_str)
+                .collect::<Vec<_>>(),
+            other
+                .qs
+                .as_ref()
+                .unwrap()
+                .iter()
+                .map(Regex::as_str)
+                .collect::<Vec<_>>()
+        );
+
+        let expected_json = r#"{"method":"GET","pattern":"/some/{_}/id$?n={_}&order=asc"}"#;
+        assert_eq!(json, expected_json);
+
+        Ok(())
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,5 @@
 #[macro_use]
 pub mod compat;
 pub use compat::features::Never;
+
+pub mod string;

--- a/src/util/string.rs
+++ b/src/util/string.rs
@@ -1,0 +1,57 @@
+use std::prelude::v1::*;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(from = "String", into = "String")
+)]
+#[repr(transparent)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AllCaps(String);
+
+impl AllCaps {
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl From<&str> for AllCaps {
+    fn from(s: &str) -> Self {
+        Self(s.to_ascii_uppercase())
+    }
+}
+
+impl From<String> for AllCaps {
+    fn from(mut s: String) -> Self {
+        s.make_ascii_uppercase();
+        Self(s)
+    }
+}
+
+impl From<AllCaps> for String {
+    fn from(a: AllCaps) -> Self {
+        a.into_inner()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn ensure_all_caps_always_is_fully_capitalized() {
+        let mixed_case_s = "miX3d_case-str^Ng.";
+
+        let all_caps = AllCaps::from(mixed_case_s);
+
+        assert_eq!(all_caps.as_str(), mixed_case_s.to_ascii_uppercase());
+        assert_eq!(all_caps.into_inner(), "MIX3D_CASE-STR^NG.");
+    }
+}


### PR DESCRIPTION
This introduces optional features useful for proxies:

- rest-mappings
- rest-mappings-serde

Compatibility: while these do not enforce the "std" feature, they
currently end up requiring it effectively because of the regular
expression engine requirements.

This implements the matching of HTTP (REST) mapping rules via inspection
of the HTTP method, path and query string.

The current implementation is just an approximation of what Apicast is
currently doing. There are a few reasons for this, not the least that
the documentation underspecifies this functionality and that Apicast
itself just passes down unchecked contents to its PCRE-based regular
expression engine.

In particular, this specification allows users to specify:

- Method: the HTTP verb literal string or the string "any"
  (case-insensitive).
- Pattern: the path and the query string pattern to match against the
  actual path and query string of requests.

Methods must match the precise HTTP verb string, case-insensitive, or
use the special method "any", which matches all methods. Note that when
you set up a rule, you can use any other string as well, allowing for
new verbs.

Patterns are a bit of a mess, though. The general rule is that you can
use placeholders for values in paths matching a superset of the
alphanumeric characters, and use the same placeholders in query string
parameter values (not keys) that match just word characters and
underscore and dash. You do so by indicating them inside curly braces
like "/path/{id}?key={val}" - at least one character is required in
between the braces, though, and the matches also require at least one
character.

In the case of the path, streams of repeated forward slashes will be
converted to a single slash, and the $ dollar sign at the end of the
path part of the pattern is guaranteed to mean an exact match (ie.
"pear$" will match "pear" but not "pears"). Whatever your pattern it
will always match at the beginning of your path, so "/hello" will match
"/hello/world" but it won't match "/world/hello".

In the case of the query string, parameter keys and values will match
any order in which they appear, so "/path$?a=1&b={_}" will match
"/path?a=1&b=2" and it will also match "/path?b=3&a=1". Specified
patterns are requirements, so the presence of other unspecified
parameters does not make a difference.

However while with path patterns there's some sense into implicitly
assuming that the literal pattern should be matching, with query string
parameter values there is no such information, and in fact Apicast seems
to only look for whether a pattern exists or not to consider any value a
match.

Just like this point above, many things are not well defined or
questionable:

- What if the $ sign at the end of a pattern is preceded by a \?
- What if the $ sign appears elsewhere in the path?
- What if regular expression special characters are used outside the
  curly braces placeholders, like `[` or `(`?
- Do query string patterns also match from the beginning? Do they also
  support using $ at the end? At the end of the parameter name or value?
  Do both names and values have implicit matches to their respective
  beginnings? Do placeholders in values match assuming the whole value
  is variable or can placeholders work like path patterns with some
  literal parts, ie. /numbers-ending-with-1$?n={num}1
- Do placeholders always need at least one character? (ie. see previous
  point where n=1 would not match)
- Can you use placeholders in query string parameter keys?

There are quite a lot of places where this underspecification can bite a
user and the implementor.

The documentation also states that you can use placeholders recursively,
which both Apicast and this implementation don't support (at least not
correctly), but you'd be hardpressed to find value in that. The
documenttion also states other quite suspect things like Apicast looking
at POST/DELETE/etc bodies to match query string parameters (which this
implementation completely does not even pretend to do).

So because there is so much not specified, underspecified or just plain
wrong in the documentation, there are quite a few issues with the
current mapping rules implementations, including this one.

Apicast just looks for placeholders in paths and in query string
parameter values. With path patterns it uses a specific regular
expression to capture path segments (or parts), and with query string
parameter values it just looks at whether the value has a placeholder,
in which case everything matches directly, or if not it compares the
value literally for a match.

The thing is that whenever the pattern has been modified to contain a
regular expression, Apicast will then submit the whole string down to
its PCRE engine for evaluation. This way they support the above
definition, but they do so at the expense of leaving the interpretation
of all characters outside the placeholders to the regex engine. So a $
character outside a placeholder would only match the end of the string,
but if it is escaped with a backslash then it just means a literal $
sign. So because Apicast just passes down everything unescaped, lots of
additional behaviour is now trapped behind the interpretation of the
exact engine used.

So our implementation behaves the same by replacing placeholders and
submitting everything else down to our engine (which should be mostly
PCRE-compatible). Doing so this way feels wrong and is not specified,
that is, no one told the user that `/path[0-9]/id` would match
`path5/id`, for example, but instead they'd think it matches the literal
path including the brackets.

In the case of query string parameters this implementation also allows
placeholders in parameter keys but it escapes absolutely everything not
within the placeholders, which breaks the case of ending these patterns
with a $ character. On the other hand, using special characters outside
the placeholders won't have special meaning. It also allows for
placeholders in value positions, but they are fully evaluated to match
so that you can match on values that have literal parts, ie. `n=9{_}9`
for values that start with a 9 and have at least another one (but note
it does not mean it will end with a 9 necessarily).

Of course, the above is not coherent with how path patterns are being
matched. But there is little coherence overall, so let's change it
whenever the dust settles around this topic.

All in all, this needs discussion, agreement and docs fixing.