### PR TITLE
Minimum Supported Rust Version 1.40.0+

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ no-std-compat = { version = "^0.4", features = ["alloc"] }
 anyhow = { version = "^1", default-features = false }
 
 [build-dependencies]
-rustc_version = "^0.3"
+autocfg = { git = "https://github.com/unleashed/autocfg", branch = "probe_feature" }
 
 [[example]]
 name = "reqwest-report"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ## Rust library crate for the 3scale Service Management API
 
+![Minimum rustc version](https://img.shields.io/badge/rustc-1.40.0+-green.svg)
 [![docs.rs](https://docs.rs/threescalers/badge.svg)](https://docs.rs/threescalers)
 [![Build Status](https://travis-ci.org/3scale-rs/threescalers.svg?branch=master)](https://travis-ci.org/3scale-rs/threescalers)
 [![Build status](https://ci.appveyor.com/api/projects/status/gf7okt6bbiqf2l1d/branch/master?svg=true)](https://ci.appveyor.com/project/3scale-rs/threescalers/branch/master)
@@ -11,6 +12,11 @@
 
 This library offers types to work with the 3scale Service Management API and
 convenience implementations for some comonly used HTTP clients.
+
+## Minimum Supported Rust Version
+
+No promise is made to maintain compatibility, but a best-effort policy of supporting the MSRV announced above is kept so that we try not to bump that minimum version unnecessarily.
+Some features that pull in dependencies might require higher rustc versions based on the dependencies' MSRV.
 
 ## Status
 

--- a/build.rs
+++ b/build.rs
@@ -1,160 +1,130 @@
-// Detect nightly compilers and features.
-use rustc_version::{version_meta, Channel, Version, VersionMeta};
+static REQUIRED_MAJOR: usize = 1;
+static REQUIRED_MINOR: usize = 40;
 
-use AvailabilityStatic::*;
+#[allow(dead_code)]
+fn emit_paths_maybe_using_feature(
+    ac: &mut autocfg::AutoCfg,
+    feature: &str,
+    paths: &[&str],
+) -> bool {
+    let (mut emitted_paths, feature_paths): (Vec<_>, Vec<_>) = paths
+        .iter()
+        .map(|path| (*path, ac.emit_has_path(path)))
+        .partition(|(_, result)| *result);
 
-// Declare features used by the project.
-// Use minimum and maximum (not included) versions.
-// "always"/"unknown" for minimum and "unknown" for maximum are special.
-static FEATURES: &[Feature<'_>] = &[
-    Feature {
-        name: "nightly",
-        availability: Nightly("always", "unknown"),
-    },
-    Feature {
-        name: "test",
-        availability: NightlyGated("always", "unknown"),
-    },
-    Feature {
-        name: "never_type",
-        availability: NightlyGated("1.12.0", "unknown"),
-    },
-    Feature {
-        name: "const_saturating_int_methods",
-        availability: Stable("1.47.0", "unknown"),
-    },
-];
+    ac.emit_features_with(&[feature], |fac| {
+        let emitted_feature_paths = feature_paths
+            .iter()
+            .map(|(path, _)| (*path, fac.emit_has_path(path)))
+            .filter(|(_, result)| *result)
+            .collect::<Vec<_>>();
+        emitted_paths.extend(emitted_feature_paths.iter());
+
+        !emitted_feature_paths.is_empty()
+    });
+
+    // emit has_<feature> if all paths are emitted
+    if paths
+        .iter()
+        .all(|&path| emitted_paths.contains(&(path, true)))
+    {
+        println!("cargo:rustc-cfg=supports_{}", feature);
+        true
+    } else {
+        false
+    }
+}
+
+#[allow(dead_code)]
+fn emit_expression_maybe_using_feature(
+    ac: &mut autocfg::AutoCfg,
+    feature: &str,
+    expr: &str,
+) -> bool {
+    let cfg = format!("supports_{}", feature);
+    emit_expression_maybe_using_feature_cfg(ac, feature, &cfg, expr)
+}
+
+fn emit_expression_maybe_using_feature_cfg(
+    ac: &mut autocfg::AutoCfg,
+    feature: &str,
+    cfg: &str,
+    expr: &str,
+) -> bool {
+    if !ac.emit_expression_cfg(expr, cfg) {
+        ac.emit_features_with(&[feature], |fac| fac.emit_expression_cfg(expr, cfg))
+    } else {
+        true
+    }
+}
+
+#[allow(dead_code)]
+fn emit_constant_maybe_using_feature(ac: &mut autocfg::AutoCfg, feature: &str, expr: &str) -> bool {
+    let cfg = format!("supports_{}", feature);
+    if !ac.emit_constant_cfg(expr, &cfg) {
+        ac.emit_features_with(&[feature], |fac| fac.emit_constant_cfg(expr, &cfg))
+    } else {
+        true
+    }
+}
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let version_meta = version_meta()?;
+    let mut ac = autocfg::AutoCfg::new()?;
 
-    FEATURES
-        .iter()
-        .map(|f| f.cargo_flags(&version_meta))
-        .for_each(|fl_set| fl_set.iter().for_each(|fl| println!("{}", fl)));
+    if !ac.probe_rustc_version(REQUIRED_MAJOR, REQUIRED_MINOR) {
+        println!(
+            "cargo:warning=rustc version {}.{} or greater required, compilation might fail",
+            REQUIRED_MAJOR, REQUIRED_MINOR
+        );
+    }
+
+    let inner_deref_paths = [
+        "core::result::Result::as_deref",
+        "core::result::Result::as_deref_mut",
+    ];
+    emit_paths_maybe_using_feature(&mut ac, "inner_deref", &inner_deref_paths);
+
+    // iterator_fold_self not worth enabling, we can just define this path via expression
+    // (cannot directly `use core::iter::Iterator::reduce`)
+    ac.emit_expression_cfg(
+        "[1, 2, 3].iter().reduce(|max, e| if max >= e { max } else { e })",
+        "has_core_iter_Iterator_reduce",
+    );
+
+    emit_expression_maybe_using_feature_cfg(
+        &mut ac,
+        "str_split_once",
+        "has_str_split_once",
+        "\"t\".split_once('t')",
+    );
+
+    emit_constant_maybe_using_feature(
+        &mut ac,
+        "const_saturating_int_methods",
+        "5i32.saturating_sub(4)",
+    );
+
+    emit_expression_maybe_using_feature(
+        &mut ac,
+        "unsafe_op_in_unsafe_fn",
+        "{\n#[deny(unknown_lints, unsafe_op_in_unsafe_fn)]\nunsafe fn t() {}\nunsafe { t() }\n}",
+    );
+
+    if !ac.emit_type_cfg("!", "supports_never_type") {
+        ac.emit_features_with(&["never_type"], |fac| {
+            fac.emit_type_cfg("!", "supports_never_type")
+        });
+    }
+
+    emit_expression_maybe_using_feature(
+        &mut ac,
+        "matches_macro",
+        "{ let a = Some(5i32); matches!(a, None) }",
+    );
+
+    ac.emit_feature("test");
+
+    autocfg::rerun_path("build.rs");
 
     Ok(())
-}
-
-// *** Supporting code below ***
-enum VersionSpec {
-    AlwaysSupported,
-    EqualOrGreater(Version),
-    Between(Version, Version),
-    Lower(Version),
-}
-
-impl VersionSpec {
-    pub fn matches(&self, version: &Version) -> bool {
-        use VersionSpec::*;
-
-        match self {
-            AlwaysSupported => true,
-            EqualOrGreater(req) => version >= req,
-            Lower(req) => version < req,
-            Between(reqmin, reqmax) => version >= reqmin && version < reqmax,
-        }
-    }
-}
-
-impl From<(&str, &str)> for VersionSpec {
-    fn from((min, top): (&str, &str)) -> VersionSpec {
-        let min_v = Version::parse(min);
-        let top_v = Version::parse(top);
-
-        match (min, top) {
-            ("unknown", "unknown") | ("always", "unknown") => VersionSpec::AlwaysSupported,
-            ("unknown", _) | ("always", _) => VersionSpec::Lower(top_v.unwrap()),
-            (_, "unknown") => VersionSpec::EqualOrGreater(min_v.unwrap()),
-            (..) => VersionSpec::Between(min_v.unwrap(), top_v.unwrap()),
-        }
-    }
-}
-
-enum Availability {
-    Stable(VersionSpec),
-    Nightly(VersionSpec),
-    NightlyGated(VersionSpec),
-}
-
-enum FeatureFlags {
-    Unavailable,
-    HasFeature,
-    HasGatedFeature,
-}
-
-struct Feature<'a> {
-    name: &'a str,
-    availability: AvailabilityStatic,
-}
-
-impl<'a> Feature<'a> {
-    pub fn name(&self) -> &str {
-        self.name
-    }
-
-    pub fn flags(&self, version_meta: &VersionMeta) -> FeatureFlags {
-        use Availability::*;
-
-        let version = &version_meta.semver;
-        let channel = version_meta.channel;
-
-        let availability = Availability::from(&self.availability);
-
-        match availability {
-            Stable(spec) if channel == Channel::Stable || channel == Channel::Beta => {
-                if spec.matches(version) {
-                    FeatureFlags::HasFeature
-                } else {
-                    FeatureFlags::Unavailable
-                }
-            }
-            Nightly(spec) if channel == Channel::Nightly => {
-                if spec.matches(version) {
-                    FeatureFlags::HasFeature
-                } else {
-                    FeatureFlags::Unavailable
-                }
-            }
-            NightlyGated(spec) if channel == Channel::Nightly => {
-                if spec.matches(version) {
-                    FeatureFlags::HasGatedFeature
-                } else {
-                    FeatureFlags::Unavailable
-                }
-            }
-            _ => FeatureFlags::Unavailable,
-        }
-    }
-
-    pub fn cargo_flags(&self, version_meta: &VersionMeta) -> Box<[String]> {
-        match self.flags(version_meta) {
-            FeatureFlags::HasFeature => [format!("cargo:rustc-cfg=has_{}", self.name())].into(),
-            FeatureFlags::HasGatedFeature => [
-                format!("cargo:rustc-cfg=has_{}", self.name()),
-                format!("cargo:rustc-cfg=feature_gate_{}", self.name()),
-            ]
-            .into(),
-            FeatureFlags::Unavailable => [].into(),
-        }
-    }
-}
-
-enum AvailabilityStatic {
-    Stable(&'static str, &'static str),
-    NightlyGated(&'static str, &'static str),
-    Nightly(&'static str, &'static str),
-}
-
-impl From<&AvailabilityStatic> for Availability {
-    fn from(avs: &AvailabilityStatic) -> Availability {
-        use Availability as Av;
-        use AvailabilityStatic::*;
-
-        match *avs {
-            Stable(min, top) => Av::Stable((min, top).into()),
-            Nightly(min, top) => Av::Nightly((min, top).into()),
-            NightlyGated(min, top) => Av::NightlyGated((min, top).into()),
-        }
-    }
 }

--- a/src/http/parameters.rs
+++ b/src/http/parameters.rs
@@ -118,7 +118,9 @@ impl Parameters {
     }
 }
 
-#[cfg(all(test, has_nightly))]
+// can't test directly for test::Bencher because autocfg lacks support for now,
+// so use feature_test which is already a guarantee of running nightly.
+#[cfg(all(test, feature_test))]
 mod benches {
     use super::*;
     use test::Bencher;

--- a/src/http/request/http_types.rs
+++ b/src/http/request/http_types.rs
@@ -96,7 +96,7 @@ impl TryFrom<&ApiCall<'_, '_, '_, '_, '_, '_>> for HTTPRequest<String> {
 }
 
 use super::SetupRequest;
-use crate::Never;
+use crate::util::Never;
 
 impl SetupRequest<'_, Never, Result<HTTPRequest<String>, Error>> for Builder {
     fn setup_request(&mut self, r: Request, _params: Never) -> Result<HTTPRequest<String>, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,12 +10,6 @@ use std::prelude::v1::*;
 #[cfg(all(test, feature_test))]
 extern crate test;
 
-// Define a never type useful for some traits (ie. SetupRequest)
-#[cfg(supports_never_type)]
-pub type Never = !;
-#[cfg(not(supports_never_type))]
-pub type Never = core::convert::Infallible;
-
 // Macros declared here, so this module should come first.
 #[macro_use]
 pub(crate) mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,10 @@ pub type Never = !;
 #[cfg(not(supports_never_type))]
 pub type Never = core::convert::Infallible;
 
+// Macros declared here, so this module should come first.
+#[macro_use]
+pub(crate) mod util;
+
 pub mod api_call;
 pub mod application;
 pub mod credentials;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,19 @@
 #![deny(clippy::all)]
-#![cfg_attr(feature_gate_never_type, feature(never_type))]
-#![cfg_attr(
-    feature_gate_const_saturating_int_methods,
-    feature(const_saturating_int_methods)
-)]
-#![cfg_attr(feature_gate_test, feature(test))]
+#![cfg_attr(feature_never_type, feature(never_type))]
+#![cfg_attr(feature_matches_macro, feature(matches_macro))]
+#![cfg_attr(feature_inner_deref, feature(inner_deref))]
+#![cfg_attr(feature_test, feature(test))]
 #![no_std]
 extern crate no_std_compat as std;
 use std::prelude::v1::*;
 
-#[cfg(all(test, has_test))]
+#[cfg(all(test, feature_test))]
 extern crate test;
 
 // Define a never type useful for some traits (ie. SetupRequest)
-#[cfg(feature_gate_never_type)]
+#[cfg(supports_never_type)]
 pub type Never = !;
-#[cfg(not(has_never_type))]
+#[cfg(not(supports_never_type))]
 pub type Never = core::convert::Infallible;
 
 pub mod api_call;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,2 @@
+#[macro_use]
+pub mod compat;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,2 +1,3 @@
 #[macro_use]
 pub mod compat;
+pub use compat::features::Never;

--- a/src/util/compat.rs
+++ b/src/util/compat.rs
@@ -1,0 +1,3 @@
+pub mod features;
+#[macro_use]
+pub mod macros;

--- a/src/util/compat/features.rs
+++ b/src/util/compat/features.rs
@@ -1,0 +1,9 @@
+#[cfg(not(supports_inner_deref))]
+mod inner_deref;
+#[cfg(not(supports_inner_deref))]
+pub use inner_deref::{InnerDerefExt, InnerDerefMutExt};
+
+#[cfg(not(has_core_iter_Iterator_reduce))]
+mod iterator_fold_self;
+#[cfg(not(has_core_iter_Iterator_reduce))]
+pub use iterator_fold_self::IteratorFoldSelfExt;

--- a/src/util/compat/features.rs
+++ b/src/util/compat/features.rs
@@ -7,3 +7,6 @@ pub use inner_deref::{InnerDerefExt, InnerDerefMutExt};
 mod iterator_fold_self;
 #[cfg(not(has_core_iter_Iterator_reduce))]
 pub use iterator_fold_self::IteratorFoldSelfExt;
+
+mod never;
+pub use never::Never;

--- a/src/util/compat/features/inner_deref.rs
+++ b/src/util/compat/features/inner_deref.rs
@@ -1,0 +1,29 @@
+#[cfg(not(has_core_result_Result_as_deref))]
+pub trait InnerDerefExt<T, E>
+where
+    T: core::ops::Deref,
+{
+    fn as_deref(&self) -> Result<&T::Target, &E>;
+}
+
+#[cfg(not(has_core_result_Result_as_deref))]
+impl<T: core::ops::Deref, E> InnerDerefExt<T, E> for Result<T, E> {
+    fn as_deref(&self) -> Result<&T::Target, &E> {
+        self.as_ref().map(|t| t.deref())
+    }
+}
+
+#[cfg(not(has_core_result_Result_as_deref_mut))]
+pub trait InnerDerefMutExt<T, E>
+where
+    T: core::ops::DerefMut,
+{
+    fn as_deref_mut(&mut self) -> Result<&mut T::Target, &mut E>;
+}
+
+#[cfg(not(has_core_result_Result_as_deref_mut))]
+impl<T: core::ops::DerefMut, E> InnerDerefMutExt<T, E> for Result<T, E> {
+    fn as_deref_mut(&mut self) -> Result<&mut T::Target, &mut E> {
+        self.as_mut().map(|t| t.deref_mut())
+    }
+}

--- a/src/util/compat/features/iterator_fold_self.rs
+++ b/src/util/compat/features/iterator_fold_self.rs
@@ -1,0 +1,24 @@
+pub trait IteratorFoldSelfExt: core::iter::Iterator {
+    // this feature used to have fold_first as well,
+    // but since the impl is so simple, we just add
+    // our own reduce even if fold_first would be
+    // available via a feature gate.
+    fn reduce<F>(self, f: F) -> Option<Self::Item>
+    where
+        Self: Sized,
+        F: FnMut(Self::Item, Self::Item) -> Self::Item;
+}
+
+impl<I> IteratorFoldSelfExt for I
+where
+    I: core::iter::Iterator,
+{
+    fn reduce<F>(mut self, f: F) -> Option<Self::Item>
+    where
+        Self: Sized,
+        F: FnMut(Self::Item, Self::Item) -> Self::Item,
+    {
+        let first = self.next()?;
+        Some(self.fold(first, f))
+    }
+}

--- a/src/util/compat/features/never.rs
+++ b/src/util/compat/features/never.rs
@@ -1,0 +1,7 @@
+// Depending on features used, this type might become unused
+#[cfg(supports_never_type)]
+#[allow(dead_code)]
+pub type Never = !;
+#[cfg(not(supports_never_type))]
+#[allow(dead_code)]
+pub type Never = core::convert::Infallible;

--- a/src/util/compat/macros.rs
+++ b/src/util/compat/macros.rs
@@ -1,0 +1,10 @@
+#[cfg(not(supports_macro_matches))]
+#[macro_export]
+macro_rules! matches {
+    ($expression:expr, $( $pattern:pat )|+ $( if $guard: expr )? $(,)?) => {
+        match $expression {
+            $( $pattern )|+ $( if $guard )? => true,
+            _ => false
+        }
+    }
+}


### PR DESCRIPTION
With this PR the following command compiles just fine:

> cargo +1.40.0 build --no-default-features --features std,http-types,xml-response

This currently pulls in full functionality without `curl` and `reqwest` integrations (which will require a higher rustc version if used).

Going lower than 1.40.0 is possible but would require forking several dependencies to fix incompatibilities or disabling useful non-integration features like `xml-response`.

This PR uses a fork of `autocfg` that can test for features and improves a lot on the existing `build.rs` program by testing for paths/types/features rather than relying on hardcoded compiler channel and version databases, which prove tricky to scale. It's not likely that the fork will make it back to the upstream `autocfg` as is, but we won't be moving to the upstream until the capability to test for features is included.