### PR TITLE
misc: add repr(transparent) to more unit structs

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -6,12 +6,16 @@ use crate::Error;
 
 use std::str::FromStr;
 
+#[repr(transparent)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct AppId(String);
+#[repr(transparent)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct AppKey(String);
+#[repr(transparent)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct UserKey(String);
+#[repr(transparent)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct OAuthToken(String);
 

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -6,8 +6,10 @@ use crate::Error;
 
 use std::str::FromStr;
 
+#[repr(transparent)]
 #[derive(Debug)]
 pub struct ProviderKey(String);
+#[repr(transparent)]
 #[derive(Debug)]
 pub struct ServiceToken(String);
 
@@ -142,6 +144,7 @@ where
     }
 }
 
+#[repr(transparent)]
 #[derive(Debug)]
 pub struct ServiceId(String);
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -28,8 +28,8 @@ impl Method {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
 #[repr(transparent)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct HeaderMap(BTreeMap<String, String>);
 
 impl HeaderMap {

--- a/src/response.rs
+++ b/src/response.rs
@@ -258,6 +258,7 @@ pub struct UsageData {
     current_value: u64,
 }
 
+#[repr(transparent)]
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Metric(pub String);
 


### PR DESCRIPTION
This becomes useful mainly for exposing these types across FFI without
surprising effects.