### PR TITLE
misc: simplify lifetimes

### DIFF
--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -65,7 +65,7 @@ pub trait SetupRequest<'client, P, Output> {
     fn setup_request(&'client mut self, r: Request, params: P) -> Output;
 }
 
-impl From<&ApiCall<'_, '_, '_, '_, '_, '_>> for Request {
+impl From<&ApiCall<'_>> for Request {
     fn from(apicall: &ApiCall) -> Self {
         let (method, path) =
             Request::endpoint(apicall.kind(), apicall.application(), apicall.user());

--- a/src/http/request/http_types.rs
+++ b/src/http/request/http_types.rs
@@ -86,7 +86,7 @@ impl TryFrom<Request> for HTTPRequest<String> {
     }
 }
 
-impl TryFrom<&ApiCall<'_, '_, '_, '_, '_, '_>> for HTTPRequest<String> {
+impl TryFrom<&ApiCall<'_>> for HTTPRequest<String> {
     type Error = Error;
 
     fn try_from(i: &ApiCall) -> Result<Self, Self::Error> {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -3,18 +3,18 @@ use std::prelude::v1::*;
 use super::{application::Application, usage::Usage, user::User, ToParams};
 
 #[derive(Clone, Debug)]
-pub struct Transaction<'app, 'user, 'usage> {
-    application: &'app Application,
-    user: Option<&'user User>,
-    usage: Option<&'usage Usage<'usage>>,
+pub struct Transaction<'a> {
+    application: &'a Application,
+    user: Option<&'a User>,
+    usage: Option<&'a Usage<'a>>,
     timestamp: Option<String>,
 }
 
-impl<'app, 'user, 'usage> Transaction<'app, 'user, 'usage> {
+impl<'a> Transaction<'a> {
     pub fn new(
-        application: &'app Application,
-        user: Option<&'user User>,
-        usage: Option<&'usage Usage>,
+        application: &'a Application,
+        user: Option<&'a User>,
+        usage: Option<&'a Usage>,
         timestamp: Option<i64>,
     ) -> Self {
         Self {
@@ -44,7 +44,7 @@ impl<'app, 'user, 'usage> Transaction<'app, 'user, 'usage> {
 
 use std::borrow::Cow;
 
-impl<'k, 'v, 'this, E> ToParams<'k, 'v, 'this, E> for Transaction<'_, '_, '_>
+impl<'k, 'v, 'this, E> ToParams<'k, 'v, 'this, E> for Transaction<'_>
 where
     'this: 'k + 'v,
     E: Extend<(Cow<'k, str>, &'v str)>,


### PR DESCRIPTION
Some structs have multiple lifetimes to make all of them independent from
each other. We have covariant lifetimes and I think having a single
lifetime may be enough to simplify code and cause no regressions.

So far the examples run unmodified but I have to check other users.