### PR TITLE
Support app_keys_list extension

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -122,6 +122,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "{ let a = Some(5i32); matches!(a, None) }",
     );
 
+    emit_expression_maybe_using_feature(
+        &mut ac,
+        "transparent_enums",
+        "{\n#[repr(transparent)]\npub enum MaybeTransparent { A }\n}",
+    );
+
     ac.emit_feature("test");
 
     autocfg::rerun_path("build.rs");

--- a/src/api_call.rs
+++ b/src/api_call.rs
@@ -9,7 +9,7 @@ use crate::{
 
 use crate::ToParams;
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Kind {
     Authorize,
     AuthRep,
@@ -24,7 +24,7 @@ impl Kind {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ApiCall<'a> {
     kind: Kind,
     service: &'a Service,
@@ -32,7 +32,7 @@ pub struct ApiCall<'a> {
     extensions: Option<&'a List<'a>>,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Builder<'a> {
     service: &'a Service,
     kind: Option<Kind>,

--- a/src/application.rs
+++ b/src/application.rs
@@ -7,16 +7,16 @@ use crate::Error;
 use std::str::FromStr;
 
 #[repr(transparent)]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AppId(String);
 #[repr(transparent)]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AppKey(String);
 #[repr(transparent)]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UserKey(String);
 #[repr(transparent)]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OAuthToken(String);
 
 // These trait impls provide a way to reference our types as &str
@@ -139,7 +139,7 @@ impl From<String> for OAuthToken {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Application {
     AppId(AppId, Option<AppKey>),
     UserKey(UserKey),

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -7,13 +7,13 @@ use crate::Error;
 use std::str::FromStr;
 
 #[repr(transparent)]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProviderKey(String);
 #[repr(transparent)]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ServiceToken(String);
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Credentials {
     ProviderKey(ProviderKey),
     ServiceToken(ServiceToken),
@@ -145,7 +145,7 @@ where
 }
 
 #[repr(transparent)]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ServiceId(String);
 
 impl AsRef<str> for ServiceId {

--- a/src/extensions/extension.rs
+++ b/src/extensions/extension.rs
@@ -8,6 +8,7 @@ pub enum Extension<'s> {
     FlatUsage(Cow<'s, str>),
     Hierarchy,
     NoBody,
+    AppKeysList(Cow<'s, str>),
     Other(Cow<'s, str>, Cow<'s, str>),
 }
 
@@ -17,13 +18,14 @@ impl Extension<'_> {
             Extension::Other(k, _) => k,
             Extension::FlatUsage(..) => "flat_usage",
             Extension::Hierarchy => "hierarchy",
+            Extension::AppKeysList(..) => "app_keys_list",
             Extension::NoBody => "no_body",
         }
     }
 
     pub fn value(&self) -> &'_ str {
         match self {
-            Extension::Other(_, v) | Extension::FlatUsage(v) => v,
+            Extension::Other(_, v) | Extension::FlatUsage(v) | Extension::AppKeysList(v) => v,
             Extension::Hierarchy | Extension::NoBody => "1",
         }
     }
@@ -36,6 +38,7 @@ impl Extension<'_> {
             Extension::Other(k, v) => encode(k) + "=" + encode(v),
             Extension::FlatUsage(value) => Cow::from("flat_usage=") + value.as_ref(),
             Extension::Hierarchy => "hierarchy=1".into(),
+            Extension::AppKeysList(value) => Cow::from("app_keys_list=") + value.as_ref(),
             Extension::NoBody => "no_body=1".into(),
         }
     }
@@ -83,6 +86,10 @@ mod tests {
         assert_eq!(
             Extension::FlatUsage(1.to_string().into()).to_string(),
             Extension::FlatUsage(1.to_string().into()).to_encoded_string()
+        );
+        assert_eq!(
+            Extension::AppKeysList(1.to_string().into()).to_string(),
+            Extension::AppKeysList(1.to_string().into()).to_encoded_string()
         );
         let ext = Extension::Other("some;[]key&%1".into(), "a_^&[]%:;@value".into());
         assert_eq!(ext.to_string(), ext.to_encoded_string());

--- a/src/extensions/extension.rs
+++ b/src/extensions/extension.rs
@@ -2,8 +2,8 @@ use std::prelude::v1::*;
 
 use std::borrow::Cow;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
-#[derive(Debug, Clone, PartialEq)]
 pub enum Extension<'s> {
     FlatUsage(Cow<'s, str>),
     Hierarchy,

--- a/src/extensions/list.rs
+++ b/src/extensions/list.rs
@@ -4,8 +4,8 @@ use std::{borrow::Cow, iter::FromIterator, vec::IntoIter};
 
 use super::Extension;
 
-#[derive(Debug, Clone, PartialEq, Default)]
 #[repr(transparent)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct List<'s>(Vec<Extension<'s>>);
 
 impl<'s> From<Vec<Extension<'s>>> for List<'s> {

--- a/src/http.rs
+++ b/src/http.rs
@@ -2,8 +2,8 @@ use std::prelude::v1::*;
 
 use std::collections::{btree_map::Iter as InnerIter, BTreeMap};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(clippy::upper_case_acronyms)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Method {
     GET,
@@ -30,7 +30,7 @@ impl Method {
 }
 
 #[repr(transparent)]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HeaderMap(BTreeMap<String, String>);
 
 impl HeaderMap {
@@ -69,6 +69,7 @@ impl Default for HeaderMap {
 }
 
 #[repr(transparent)]
+#[derive(Debug, Clone)]
 pub struct Iter<'a> {
     iter: InnerIter<'a, String, String>,
 }

--- a/src/http/parameters.rs
+++ b/src/http/parameters.rs
@@ -3,7 +3,7 @@ use std::prelude::v1::*;
 use super::Method;
 use std::borrow::Cow;
 
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Parameters {
     Query(String),
     Body(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(feature_matches_macro, feature(matches_macro))]
 #![cfg_attr(feature_inner_deref, feature(inner_deref))]
 #![cfg_attr(feature_test, feature(test))]
+#![cfg_attr(feature_transparent_enums, feature(transparent_enums))]
 #![no_std]
 extern crate no_std_compat as std;
 use std::prelude::v1::*;

--- a/src/response.rs
+++ b/src/response.rs
@@ -310,6 +310,45 @@ mod tests {
     }
 
     #[test]
+    fn parse_denied_authorization() {
+        let xml_response = r##"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <status>
+          <authorized>false</authorized>
+          <reason>application key is missing</reason>
+          <plan>sample</plan>
+          <usage_reports>
+            <usage_report metric="ticks" period="minute">
+              <period_start>2021-06-08 18:07:00 +0000</period_start>
+              <period_end>2021-06-08 18:08:00 +0000</period_end>
+              <max_value>5</max_value>
+              <current_value>0</current_value>
+            </usage_report>
+          </usage_reports>
+        </status>
+        "##;
+
+        let parsed_auth = Authorization::from_str(xml_response).unwrap();
+
+        let expected_auth = Authorization::Status(AuthorizationStatus {
+            authorized: false,
+            reason: Some("application key is missing".into()),
+            plan: "sample".into(),
+            usage_reports: Some(UsageReports(vec![UsageReport {
+                metric: String::from("ticks"),
+                period: Period::Minute,
+                period_start: Utc.ymd(2021, 6, 8).and_hms(18, 7, 0).into(),
+                period_end: Utc.ymd(2021, 6, 8).and_hms(18, 8, 0).into(),
+                max_value: 5,
+                current_value: 0,
+            }])),
+            metrics_hierarchy: None,
+            app_keys: None,
+        });
+        assert_eq!(expected_auth, parsed_auth);
+    }
+
+    #[test]
     fn parse_metrics_hierarchy() {
         let xml_response = r##"
         <?xml version="1.0" encoding="UTF-8"?>

--- a/src/response.rs
+++ b/src/response.rs
@@ -18,7 +18,7 @@ mod systemtime {
     use chrono::DateTime;
 
     #[repr(transparent)]
-    #[derive(Debug, PartialEq)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct PeriodTime(pub i64);
 
     impl<Tz: chrono::TimeZone> From<DateTime<Tz>> for PeriodTime {
@@ -30,7 +30,7 @@ mod systemtime {
 
 pub use systemtime::PeriodTime;
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(rename = "usage_report")]
 pub struct UsageReport {
     pub metric: String,
@@ -43,20 +43,21 @@ pub struct UsageReport {
 
 // Unfortunately the XML output from Apisonator includes a rather useless "usage_reports" tag that
 // is then followed by a "usage_report" tag in each UsageReport, so we need to wrap that up.
-#[derive(Debug, Deserialize, PartialEq)]
+#[repr(transparent)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub enum UsageReports {
     #[serde(rename = "usage_report")]
     UsageReports(Vec<UsageReport>),
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum Authorization {
     Status(AuthorizationStatus),
     Error(AuthorizationError),
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct AuthorizationStatus {
     authorized: bool,
     reason: Option<String>,
@@ -70,12 +71,13 @@ pub struct AuthorizationStatus {
     app_keys: Option<AppKeysList>,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[repr(transparent)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct AuthorizationError {
     code: String,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Period {
     Minute,
     Hour,

--- a/src/response.rs
+++ b/src/response.rs
@@ -43,7 +43,7 @@ pub struct UsageReport {
 
 // Unfortunately the XML output from Apisonator includes a rather useless "usage_reports" tag that
 // is then followed by a "usage_report" tag in each UsageReport, so we need to wrap that up.
-#[repr(transparent)]
+#[cfg_attr(supports_transparent_enums, repr(transparent))]
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub enum UsageReports {
     #[serde(rename = "usage_report")]

--- a/src/response/app_keys_list.rs
+++ b/src/response/app_keys_list.rs
@@ -1,0 +1,101 @@
+use std::prelude::v1::*;
+
+use std::fmt;
+
+use serde::{
+    de::{Deserializer, MapAccess, Visitor},
+    Deserialize,
+};
+
+use crate::{
+    application::{AppId, AppKey},
+    credentials::ServiceId,
+};
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct AppKeysList {
+    service_id: Option<ServiceId>,
+    app_id: Option<AppId>,
+    keys: Vec<AppKey>,
+}
+
+impl AppKeysList {
+    pub fn new<S: Into<ServiceId>, A: Into<AppId>, K: Into<AppKey>, I: IntoIterator<Item = K>>(
+        service_id: Option<S>,
+        app_id: Option<A>,
+        keys: I,
+    ) -> Self {
+        Self {
+            service_id: service_id.map(Into::into),
+            app_id: app_id.map(Into::into),
+            keys: keys.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    pub fn service_id(&self) -> Option<&ServiceId> {
+        self.service_id.as_ref()
+    }
+
+    pub fn app_id(&self) -> Option<&AppId> {
+        self.app_id.as_ref()
+    }
+
+    pub fn keys(&self) -> &[AppKey] {
+        self.keys.as_slice()
+    }
+}
+
+struct AppKeysListVisitor;
+
+impl<'de> Visitor<'de> for AppKeysListVisitor {
+    type Value = AppKeysList;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a structure that represents the application's keys")
+    }
+
+    fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+    where
+        V: MapAccess<'de>,
+    {
+        #[derive(Debug, Deserialize)]
+        struct AppKeyWithId {
+            id: String,
+        }
+
+        let mut app_id: Option<AppId> = None;
+        let mut service_id: Option<ServiceId> = None;
+        // the usual maximum capacity is 5 entries
+        let mut keys: Vec<AppKey> = Vec::with_capacity(5);
+
+        while let Some(ref attr) = map.next_key::<String>()? {
+            match attr.as_str() {
+                "app" => {
+                    app_id = Some(map.next_value::<String>()?.into());
+                }
+                "svc" => {
+                    service_id = Some(map.next_value::<String>()?.into());
+                }
+                "key" => {
+                    let appkeyid = map.next_value::<AppKeyWithId>()?;
+                    keys.push(AppKey::from(appkeyid.id));
+                }
+                // unknown keys are just ignored
+                _ => (),
+            }
+        }
+
+        let list_app_keys = AppKeysList::new(service_id, app_id, keys);
+
+        Ok(list_app_keys)
+    }
+}
+
+impl<'de> Deserialize<'de> for AppKeysList {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(AppKeysListVisitor)
+    }
+}

--- a/src/response/app_keys_list.rs
+++ b/src/response/app_keys_list.rs
@@ -12,7 +12,7 @@ use crate::{
     credentials::ServiceId,
 };
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AppKeysList {
     service_id: Option<ServiceId>,
     app_id: Option<AppId>,

--- a/src/response/metrics_hierarchy.rs
+++ b/src/response/metrics_hierarchy.rs
@@ -15,7 +15,7 @@ use serde::{
 
 // We might want to consider moving from a BTreeMap to a Vec, as most of the time this btreemap will
 // contain a (very) small number of entries.
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct MetricsHierarchy(BTreeMap<String, Vec<String>>);
 
 impl MetricsHierarchy {

--- a/src/response/metrics_hierarchy.rs
+++ b/src/response/metrics_hierarchy.rs
@@ -1,0 +1,107 @@
+use std::prelude::v1::*;
+
+use std::{
+    collections::{
+        btree_map::{Iter, IterMut},
+        BTreeMap,
+    },
+    fmt,
+};
+
+use serde::{
+    de::{self, Deserializer, MapAccess, Visitor},
+    Deserialize,
+};
+
+// We might want to consider moving from a BTreeMap to a Vec, as most of the time this btreemap will
+// contain a (very) small number of entries.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct MetricsHierarchy(BTreeMap<String, Vec<String>>);
+
+impl MetricsHierarchy {
+    pub fn new() -> Self {
+        Self(BTreeMap::new())
+    }
+
+    pub fn insert<S: Into<String>, V: Into<Vec<String>>>(
+        &mut self,
+        parent_metric: S,
+        children_metrics: V,
+    ) -> Option<Vec<String>> {
+        self.0.insert(parent_metric.into(), children_metrics.into())
+    }
+
+    pub fn remove<S: AsRef<str>>(&mut self, parent_metric: S) -> Option<Vec<String>> {
+        self.0.remove(parent_metric.as_ref())
+    }
+
+    pub fn iter(&self) -> Iter<String, Vec<String>> {
+        self.0.iter()
+    }
+
+    pub fn iter_mut(&mut self) -> IterMut<String, Vec<String>> {
+        self.0.iter_mut()
+    }
+
+    pub fn into_inner(self) -> BTreeMap<String, Vec<String>> {
+        self.0
+    }
+
+    /// Retrieves the parent metric of a given metric. Note that Apisonator metrics have 0 or
+    /// 1 parent metrics, not multiple.
+    pub fn parent_of(&self, metric_name: &str) -> Option<&str> {
+        self.iter().find_map(|(parent, v)| {
+            if v.iter().any(|child| metric_name == child) {
+                Some(parent.as_str())
+            } else {
+                None
+            }
+        })
+    }
+}
+
+struct MetricsHierarchyVisitor;
+
+impl<'de> Visitor<'de> for MetricsHierarchyVisitor {
+    type Value = MetricsHierarchy;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a structure that represents a hierarchy of metrics")
+    }
+
+    fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+    where
+        V: MapAccess<'de>,
+    {
+        let mut hierarchy = MetricsHierarchy::new();
+
+        // The key in the hierarchy structure is always "metric". It is not
+        // used, but we need to read it to get the value.
+        while map.next_key::<String>()?.is_some() {
+            let val: BTreeMap<String, String> = map.next_value()?;
+
+            let parent_metric = val
+                .get("name")
+                .ok_or_else(|| de::Error::missing_field("name"))?;
+            let children_metrics = val
+                .get("children")
+                .ok_or_else(|| de::Error::missing_field("children"))?
+                .split(' ')
+                .map(|s| s.to_owned())
+                .collect::<Vec<_>>();
+
+            hierarchy.insert(parent_metric.to_owned(), children_metrics);
+        }
+
+        Ok(hierarchy)
+    }
+}
+
+impl<'de> Deserialize<'de> for MetricsHierarchy {
+    fn deserialize<D>(deserializer: D) -> Result<MetricsHierarchy, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(MetricsHierarchyVisitor)
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -5,7 +5,7 @@ use crate::{
     ToParams,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Service {
     service_id: ServiceId,
     creds: Credentials,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -2,7 +2,7 @@ use std::prelude::v1::*;
 
 use super::{application::Application, usage::Usage, user::User, ToParams};
 
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Transaction<'a> {
     application: &'a Application,
     user: Option<&'a User>,

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -2,7 +2,7 @@ use std::prelude::v1::*;
 
 use crate::ToParams;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MetricUsage<'m>(&'m str, &'m str);
 
 impl<'m, M: AsRef<str> + 'm, V: AsRef<str> + 'm> From<&'m (M, V)> for MetricUsage<'m> {
@@ -11,7 +11,8 @@ impl<'m, M: AsRef<str> + 'm, V: AsRef<str> + 'm> From<&'m (M, V)> for MetricUsag
     }
 }
 
-#[derive(Debug, Clone)]
+#[repr(transparent)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Usage<'m>(Vec<MetricUsage<'m>>);
 
 impl<'m, M: AsRef<str> + 'm, V: AsRef<str> + 'm> From<&'m [(M, V)]> for Usage<'m> {

--- a/src/user.rs
+++ b/src/user.rs
@@ -4,9 +4,12 @@ use crate::{Error, ToParams};
 
 use std::str::FromStr;
 
-#[derive(Debug)]
+#[repr(transparent)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UserId(String);
-#[derive(Debug)]
+
+#[repr(transparent)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OAuthToken(String);
 
 // These trait impls provide a way to reference our types as &str
@@ -71,7 +74,7 @@ impl From<String> for OAuthToken {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum User {
     UserId(UserId),
     OAuthToken(OAuthToken),


### PR DESCRIPTION
This implements support for the [`app_keys_list` extension](https://github.com/3scale/apisonator/issues/282) and refactors the `response` module to reduce complexity by extracting the support for metric hierarchies to its own module and fixes the following bugs:

1. The `Authorization` enum incorrectly tagged Auth* calls that failed (NB: **not denied**, but failed) as denied.
2. The enum above did not contain the authorization status due to assuming that not having an error meant a call was authorized.
3. Some authorization calls might have no usage reports because of no limits set, but the logic required usage_reports to exist.

This PR also introduces a standardization of opt-in built-in traits (ie. `Debug, Clone, PartialEq, Eq` are the usual ones) in most places to help with usability (and a small fix by removing an incorrect `Copy` in an enum that can contain heap data).

What this PR does not address and should be coming in a follow-up is adding suitable `pub` methods to `Authorization` and related structs so that the authorization data, including the one from the `app_keys_list` extension, can be accessed by a user.

Please consider merging this PR **before** #89 - it's easier to rebase #89 on top of this PR once merged.

N.B. This depends on the final shape the corresponding Apisonator extension implementation PR 3scale/apisonator#284 ends up taking, so merge only after that one is in.

PS. there are some outstanding issues with the XML library that persist from the pre-existing code that don't usually show up unless something really bad happens with the response. In particular, unknown tag attributes cause the library to trigger a `debug_assert()` call (in debug mode only), and as things stand now the `UsageReports` deserialization breaks if the tags are provided but no actual `UsageReport` is present (this should be fixable via a custom `Deserialize` implementation).