### PR TITLE
list_app_keys extension naming fixed

### DIFF
--- a/src/extensions/extension.rs
+++ b/src/extensions/extension.rs
@@ -8,7 +8,7 @@ pub enum Extension<'s> {
     FlatUsage(Cow<'s, str>),
     Hierarchy,
     NoBody,
-    AppKeysList(Cow<'s, str>),
+    ListAppKeys(Cow<'s, str>),
     Other(Cow<'s, str>, Cow<'s, str>),
 }
 
@@ -18,14 +18,14 @@ impl Extension<'_> {
             Extension::Other(k, _) => k,
             Extension::FlatUsage(..) => "flat_usage",
             Extension::Hierarchy => "hierarchy",
-            Extension::AppKeysList(..) => "app_keys_list",
+            Extension::ListAppKeys(..) => "list_app_keys",
             Extension::NoBody => "no_body",
         }
     }
 
     pub fn value(&self) -> &'_ str {
         match self {
-            Extension::Other(_, v) | Extension::FlatUsage(v) | Extension::AppKeysList(v) => v,
+            Extension::Other(_, v) | Extension::FlatUsage(v) | Extension::ListAppKeys(v) => v,
             Extension::Hierarchy | Extension::NoBody => "1",
         }
     }
@@ -38,7 +38,7 @@ impl Extension<'_> {
             Extension::Other(k, v) => encode(k) + "=" + encode(v),
             Extension::FlatUsage(value) => Cow::from("flat_usage=") + value.as_ref(),
             Extension::Hierarchy => "hierarchy=1".into(),
-            Extension::AppKeysList(value) => Cow::from("app_keys_list=") + value.as_ref(),
+            Extension::ListAppKeys(value) => Cow::from("list_app_keys=") + value.as_ref(),
             Extension::NoBody => "no_body=1".into(),
         }
     }
@@ -52,12 +52,7 @@ impl Extension<'_> {
     pub fn to_encoded_string(&self) -> String {
         use crate::encoding::encode;
 
-        [
-            encode(self.key()),
-            "=".into(),
-            encode(self.value().as_ref()),
-        ]
-        .concat()
+        [encode(self.key()), "=".into(), encode(self.value())].concat()
     }
 }
 
@@ -88,8 +83,8 @@ mod tests {
             Extension::FlatUsage(1.to_string().into()).to_encoded_string()
         );
         assert_eq!(
-            Extension::AppKeysList(1.to_string().into()).to_string(),
-            Extension::AppKeysList(1.to_string().into()).to_encoded_string()
+            Extension::ListAppKeys(1.to_string().into()).to_string(),
+            Extension::ListAppKeys(1.to_string().into()).to_encoded_string()
         );
         let ext = Extension::Other("some;[]key&%1".into(), "a_^&[]%:;@value".into());
         assert_eq!(ext.to_string(), ext.to_encoded_string());

--- a/src/response.rs
+++ b/src/response.rs
@@ -9,7 +9,7 @@ use serde::{
 };
 
 mod app_keys_list;
-pub use app_keys_list::AppKeysList;
+pub use app_keys_list::ListAppKeys;
 
 mod metrics_hierarchy;
 pub use metrics_hierarchy::MetricsHierarchy;
@@ -68,7 +68,7 @@ pub struct AuthorizationStatus {
     metrics_hierarchy: Option<MetricsHierarchy>,
 
     #[serde(rename = "app_keys")]
-    app_keys: Option<AppKeysList>,
+    app_keys: Option<ListAppKeys>,
 }
 
 impl AuthorizationStatus {
@@ -84,7 +84,7 @@ impl AuthorizationStatus {
         self.plan.as_ref()
     }
 
-    pub fn app_keys(&self) -> Option<&AppKeysList> {
+    pub fn app_keys(&self) -> Option<&ListAppKeys> {
         self.app_keys.as_ref()
     }
 
@@ -542,7 +542,7 @@ mod tests {
 
         let parsed_auth = Authorization::from_str(xml_response).unwrap();
 
-        let expected_app_keys = AppKeysList::new(
+        let expected_app_keys = ListAppKeys::new(
             "service_id".into(),
             "app_id".into(),
             vec!["a_secret_key", "another_secret_key"],
@@ -574,7 +574,7 @@ mod tests {
 
         let parsed_auth = Authorization::from_str(xml_response).unwrap();
 
-        let expected_app_keys = AppKeysList::new(
+        let expected_app_keys = ListAppKeys::new(
             "service_id".into(),
             "app_id".into(),
             core::iter::empty::<crate::application::AppKey>(),

--- a/src/response/app_keys_list.rs
+++ b/src/response/app_keys_list.rs
@@ -13,13 +13,13 @@ use crate::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AppKeysList {
+pub struct ListAppKeys {
     service_id: Option<ServiceId>,
     app_id: Option<AppId>,
     keys: Vec<AppKey>,
 }
 
-impl AppKeysList {
+impl ListAppKeys {
     pub fn new<S: Into<ServiceId>, A: Into<AppId>, K: Into<AppKey>, I: IntoIterator<Item = K>>(
         service_id: Option<S>,
         app_id: Option<A>,
@@ -45,10 +45,10 @@ impl AppKeysList {
     }
 }
 
-struct AppKeysListVisitor;
+struct ListAppKeysVisitor;
 
-impl<'de> Visitor<'de> for AppKeysListVisitor {
-    type Value = AppKeysList;
+impl<'de> Visitor<'de> for ListAppKeysVisitor {
+    type Value = ListAppKeys;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("a structure that represents the application's keys")
@@ -85,17 +85,17 @@ impl<'de> Visitor<'de> for AppKeysListVisitor {
             }
         }
 
-        let list_app_keys = AppKeysList::new(service_id, app_id, keys);
+        let list_app_keys = ListAppKeys::new(service_id, app_id, keys);
 
         Ok(list_app_keys)
     }
 }
 
-impl<'de> Deserialize<'de> for AppKeysList {
+impl<'de> Deserialize<'de> for ListAppKeys {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_any(AppKeysListVisitor)
+        deserializer.deserialize_any(ListAppKeysVisitor)
     }
 }


### PR DESCRIPTION
This PR fixes the list_app_keys extension naming issue inside threescalers. Fixes #92