### PR TITLE
response,extensions: add useful helpers to Authorization and Extension::List

### DIFF
--- a/src/extensions/list.rs
+++ b/src/extensions/list.rs
@@ -96,6 +96,10 @@ impl<'s> List<'s> {
     pub fn flat_usage(self, level: u32) -> Self {
         self.push(Extension::FlatUsage(level.to_string().into()))
     }
+
+    pub fn list_app_keys(self, level: u32) -> Self {
+        self.push(Extension::ListAppKeys(level.to_string().into()))
+    }
 }
 
 impl ToString for List<'_> {

--- a/src/response.rs
+++ b/src/response.rs
@@ -189,12 +189,20 @@ pub struct AuthorizationStatus {
 }
 
 impl AuthorizationStatus {
-    pub fn authorized(&self) -> bool {
+    pub fn is_authorized(&self) -> bool {
         self.authorized
     }
 
     pub fn reason(&self) -> Option<&str> {
         self.reason.as_deref()
+    }
+
+    pub fn authorized(&self) -> Result<(), &str> {
+        if self.authorized {
+            Ok(())
+        } else {
+            Err(self.reason.as_deref().unwrap_or("unspecified reason"))
+        }
     }
 
     pub fn plan(&self) -> &str {

--- a/src/response.rs
+++ b/src/response.rs
@@ -57,6 +57,41 @@ pub enum Authorization {
     Error(AuthorizationError),
 }
 
+impl Authorization {
+    pub fn is_status(&self) -> bool {
+        #[cfg(not(supports_matches_macro))]
+        match self {
+            Self::Status(_) => true,
+            _ => false,
+        }
+
+        #[cfg(supports_matches_macro)]
+        matches!(self, Self::Status(_))
+    }
+
+    pub fn is_error(&self) -> bool {
+        #[cfg(not(supports_matches_macro))]
+        match self {
+            Self::Error(_) => true,
+            _ => false,
+        }
+
+        #[cfg(supports_matches_macro)]
+        matches!(self, Self::Error(_))
+    }
+
+    // Note that the `into_inner` call will return a `Result` that is much
+    // more like an `Either`, since the Ok variant will represent the AuthStatus
+    // and the Err variant will represent the parsed AuthError, but the Err
+    // variant is not an `Error` type itself.
+    pub fn into_inner(self) -> Result<AuthorizationStatus, AuthorizationError> {
+        match self {
+            Self::Status(st) => Ok(st),
+            Self::Error(err) => Err(err),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct AuthorizationStatus {
     authorized: bool,

--- a/src/response.rs
+++ b/src/response.rs
@@ -331,12 +331,6 @@ impl<'de> Deserialize<'de> for PeriodTime {
     }
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
-pub struct UsageData {
-    max_value: u64,
-    current_value: u64,
-}
-
 #[repr(transparent)]
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Metric(pub String);

--- a/src/response.rs
+++ b/src/response.rs
@@ -94,12 +94,12 @@ impl AuthorizationStatus {
         self.app_keys.as_ref()
     }
 
-    pub fn usage_reports(&self) -> Option<&UsageReports> {
-        self.usage_reports.as_ref()
+    pub fn usage_reports(&self) -> Option<&Vec<UsageReport>> {
+        self.usage_reports.as_ref().map(|ur| ur.as_vec())
     }
 
-    pub fn usage_reports_mut(&mut self) -> Option<&mut UsageReports> {
-        self.usage_reports.as_mut()
+    pub fn usage_reports_mut(&mut self) -> Option<&mut Vec<UsageReport>> {
+        self.usage_reports.as_mut().map(|ur| ur.as_vec_mut())
     }
 
     pub fn hierarchy(&self) -> Option<&MetricsHierarchy> {

--- a/src/response.rs
+++ b/src/response.rs
@@ -217,20 +217,29 @@ impl AuthorizationStatus {
         self.usage_reports.as_ref()
     }
 
+    pub fn usage_reports_mut(&mut self) -> Option<&mut UsageReports> {
+        self.usage_reports.as_mut()
+    }
+
     pub fn hierarchy(&self) -> Option<&MetricsHierarchy> {
         self.metrics_hierarchy.as_ref()
     }
 }
 
-#[repr(transparent)]
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct AuthorizationError {
     code: String,
+    #[serde(rename = "$value")]
+    description: String,
 }
 
 impl AuthorizationError {
     pub fn code(&self) -> &str {
         self.code.as_ref()
+    }
+
+    pub fn description(&self) -> &str {
+        self.description.as_str()
     }
 }
 

--- a/src/response/usage_report.rs
+++ b/src/response/usage_report.rs
@@ -1,0 +1,293 @@
+use std::prelude::v1::*;
+
+use core::fmt;
+
+use chrono::DateTime;
+use serde::{
+    de::{self, MapAccess, Visitor},
+    Deserialize, Deserializer,
+};
+
+mod systemtime {
+    use chrono::DateTime;
+
+    #[repr(transparent)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct PeriodTime(pub i64);
+
+    impl<Tz: chrono::TimeZone> From<DateTime<Tz>> for PeriodTime {
+        fn from(dt: DateTime<Tz>) -> PeriodTime {
+            PeriodTime(dt.timestamp())
+        }
+    }
+}
+
+pub use systemtime::PeriodTime;
+
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum UsageReportError {
+    LimitsExceeded(u64),
+    Overflow,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename = "usage_report")]
+pub struct UsageReport {
+    pub metric: String,
+    pub period: Period,
+    pub period_start: PeriodTime,
+    pub period_end: PeriodTime,
+    pub max_value: u64,
+    pub current_value: u64,
+}
+
+impl UsageReport {
+    pub fn metric(&self) -> &str {
+        self.metric.as_ref()
+    }
+
+    pub fn period(&self) -> &Period {
+        &self.period
+    }
+
+    pub fn period_times(&self) -> (&PeriodTime, &PeriodTime) {
+        (&self.period_start, &self.period_end)
+    }
+
+    pub fn max_value(&self) -> u64 {
+        self.max_value
+    }
+
+    pub fn current_value(&self) -> u64 {
+        self.current_value
+    }
+
+    pub fn remaining(&self) -> u64 {
+        self.max_value.saturating_sub(self.current_value)
+    }
+
+    pub fn is_limited(&self) -> bool {
+        self.current_value >= self.max_value
+    }
+
+    pub fn authorize(&self, hits: u64) -> Result<u64, UsageReportError> {
+        let new_hits = self
+            .current_value
+            .checked_add(hits)
+            .ok_or(UsageReportError::Overflow)?;
+        if new_hits > self.max_value {
+            Err(UsageReportError::LimitsExceeded(new_hits - self.max_value))
+        } else {
+            Ok(new_hits)
+        }
+    }
+
+    pub fn report(&mut self, hits: u64) -> Result<u64, UsageReportError> {
+        self.current_value = self
+            .current_value
+            .checked_add(hits)
+            .ok_or(UsageReportError::Overflow)?;
+
+        Ok(self.current_value)
+    }
+
+    pub fn reset<V: Into<Option<u64>>>(&mut self, val: V) {
+        self.current_value = val.into().unwrap_or(0);
+    }
+}
+
+// Unfortunately the XML output from Apisonator includes a rather useless "usage_reports" tag that
+// is then followed by a "usage_report" tag in each UsageReport, so we need to wrap that up.
+#[cfg_attr(supports_transparent_enums, repr(transparent))]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub enum UsageReports {
+    #[serde(rename = "usage_report")]
+    UsageReports(Vec<UsageReport>),
+}
+
+impl UsageReports {
+    pub fn as_vec(&self) -> &Vec<UsageReport> {
+        match self {
+            Self::UsageReports(v) => v,
+        }
+    }
+
+    pub fn as_vec_mut(&mut self) -> &mut Vec<UsageReport> {
+        match self {
+            Self::UsageReports(v) => v,
+        }
+    }
+
+    pub fn into_inner(self) -> Vec<UsageReport> {
+        match self {
+            Self::UsageReports(v) => v,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Period {
+    Minute,
+    Hour,
+    Day,
+    Week,
+    Month,
+    Year,
+    Eternity,
+    Other(String),
+}
+
+struct PeriodStringVisitor;
+
+impl<'de> Visitor<'de> for PeriodStringVisitor {
+    type Value = Period;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a string that represents a period")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        match v {
+            "minute" => Ok(Period::Minute),
+            "hour" => Ok(Period::Hour),
+            "day" => Ok(Period::Day),
+            "week" => Ok(Period::Week),
+            "month" => Ok(Period::Month),
+            "year" => Ok(Period::Year),
+            "eternity" => Ok(Period::Eternity),
+            period_name => Ok(Period::Other(period_name.into())),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Period {
+    fn deserialize<D>(deserializer: D) -> Result<Period, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(PeriodStringVisitor)
+    }
+}
+
+struct TimestampVisitor;
+
+impl<'de> Visitor<'de> for TimestampVisitor {
+    type Value = PeriodTime;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a string that represents a timestamp")
+    }
+
+    fn visit_map<V>(self, mut map: V) -> Result<PeriodTime, V::Error>
+    where
+        V: MapAccess<'de>,
+    {
+        // We know there's only one key with one value.
+        // The key is not used, but we need to call "next_key()". From the
+        // docs: "Calling `next_value` before `next_key` is incorrect and is
+        // allowed to panic or return bogus results.".
+        let _key: Option<String> = map.next_key()?;
+        let timestamp: String = map.next_value()?;
+
+        let ts_str = timestamp.as_str();
+        let dt = DateTime::parse_from_str(ts_str, "%Y-%m-%d %H:%M:%S %z").map_err(|e| {
+            de::Error::custom(format_args!(
+                "invalid timestamp {}, expected %Y-%m-%d %H:%M:%S %z: {:?}",
+                ts_str, e
+            ))
+        })?;
+
+        Ok(PeriodTime::from(dt))
+    }
+}
+
+impl<'de> Deserialize<'de> for PeriodTime {
+    fn deserialize<D>(deserializer: D) -> Result<PeriodTime, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(TimestampVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::prelude::*;
+
+    fn sample_usage_report() -> UsageReport {
+        UsageReport {
+            metric: "hits".into(),
+            period: Period::Minute,
+            period_start: Utc.ymd(2021, 6, 22).and_hms(16, 58, 0).into(),
+            period_end: Utc.ymd(2021, 6, 22).and_hms(16, 59, 0).into(),
+            max_value: 10,
+            current_value: 0,
+        }
+    }
+
+    #[test]
+    fn test_usage_report_getters() {
+        let ur = sample_usage_report();
+
+        assert_eq!(ur.metric(), "hits");
+        assert_eq!(ur.period(), &Period::Minute);
+        assert_eq!(
+            ur.period_times(),
+            (
+                &PeriodTime::from(Utc.ymd(2021, 6, 22).and_hms(16, 58, 0)),
+                &PeriodTime::from(Utc.ymd(2021, 6, 22).and_hms(16, 59, 0))
+            )
+        );
+        assert_eq!(ur.max_value(), 10);
+        assert_eq!(ur.current_value(), 0);
+    }
+
+    #[test]
+    fn test_usage_report_counters() {
+        let mut ur = sample_usage_report();
+
+        assert!(!ur.is_limited());
+        let remaining = ur.remaining();
+        let auth = ur.authorize(remaining);
+        assert!(auth.is_ok());
+        let report = ur.report(remaining);
+        assert!(report.is_ok());
+        let report_val = report.unwrap();
+        assert_eq!(report_val, ur.current_value());
+        assert_eq!(report_val, ur.max_value());
+        let auth = ur.authorize(0);
+        assert!(auth.is_ok());
+        let auth = ur.authorize(1);
+        assert!(auth.is_err());
+        let exceeded_limits = auth.unwrap_err();
+        assert_eq!(exceeded_limits, UsageReportError::LimitsExceeded(1));
+        assert!(ur.is_limited());
+        ur.reset(std::u64::MAX);
+        let new_auth = ur.authorize(1);
+        assert!(new_auth.is_err());
+        let auth_err = new_auth.unwrap_err();
+        assert_eq!(auth_err, UsageReportError::Overflow);
+    }
+
+    #[test]
+    fn test_deserialization() {
+        let xml = r#"
+            <usage_report metric="hits" period="minute">
+                <period_start>2021-06-22 16:58:00 +0000</period_start>
+                <period_end>2021-06-22 16:59:00 +0000</period_end>
+                <max_value>10</max_value>
+                <current_value>0</current_value>
+            </usage_report>
+        "#;
+
+        let ur = serde_xml_rs::from_str::<UsageReport>(xml);
+        assert!(ur.is_ok());
+        let ur = ur.unwrap();
+        assert_eq!(ur, sample_usage_report());
+    }
+}


### PR DESCRIPTION
Add helpers for `Authorization` to query and extract its contents, and add a helper to `Extension::List` to easily enable the `list_app_keys` extension.