### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ http_types = { version = "^0.2", package = "http", optional = true }
 reqwest = { version = ">= 0.10, < 0.12", optional = true }
 curl = { version = "^0.4", optional = true }
 serde = { version = "^1", optional = true, default-features = false, features = ["alloc", "derive"] }
-serde-xml-rs = { version = "^0.4", optional = true }
+serde-xml-rs = { version = "^0.6", optional = true }
 chrono = { version = "^0.4", optional = true, default-features = false }
 no-std-compat = { version = "^0.4", features = ["alloc"] }
 anyhow = { version = "^1", default-features = false }


### PR DESCRIPTION
* Update to serde-xml-rs to 0.6
  * Move tests xmls to the first line, otherwise it is failing  (<?XML must be at the top)
* Replace chronos deprecated methods