### PR TITLE
util/compat: fix cfg flag for matches macro

### DIFF
--- a/src/util/compat/macros.rs
+++ b/src/util/compat/macros.rs
@@ -1,4 +1,4 @@
-#[cfg(not(supports_macro_matches))]
+#[cfg(not(supports_matches_macro))]
 #[macro_export]
 macro_rules! matches {
     ($expression:expr, $( $pattern:pat )|+ $( if $guard: expr )? $(,)?) => {


### PR DESCRIPTION
This fixes a stupid typo in the `cfg` gate for the `matches!` macro.